### PR TITLE
alternative makefile fix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,21 +46,21 @@ $(OUT)/libscsindir.a: $(OBJECTS) $(INDIRSRC)/private.o $(LINSYS)/common.o
 	$(ARCHIVE) $(OUT)/libscsindir.a $^
 	- $(RANLIB) $(OUT)/libscsindir.a
 
-$(OUT)/demo_direct: examples/c/demo.c $(OUT)/libscsdir.a
+$(OUT)/demo_direct: examples/c/demo.c $(OUT)/libscsdir.a examples/c/problemUtils.h
 	mkdir -p $(OUT)
-	$(CC) $(CFLAGS) -DDEMO_PATH="\"$(CURDIR)/examples/raw/demo_data\"" $^ -o $@ $(LDFLAGS)
+	$(CC) $(CFLAGS) -DDEMO_PATH="\"$(CURDIR)/examples/raw/demo_data\"" $< -o $@ $(LDFLAGS) -lscsdir
 
-$(OUT)/demo_indirect: examples/c/demo.c $(OUT)/libscsindir.a
+$(OUT)/demo_indirect: examples/c/demo.c $(OUT)/libscsindir.a examples/c/problemUtils.h
 	mkdir -p $(OUT)
-	$(CC) $(CFLAGS) -DDEMO_PATH="\"$(CURDIR)/examples/raw/demo_data\"" $^  -o $@ $(LDFLAGS)
+	$(CC) $(CFLAGS) -DDEMO_PATH="\"$(CURDIR)/examples/raw/demo_data\"" $< -o $@ $(LDFLAGS) -lscsindir
 
-$(OUT)/demo_SOCP_direct: examples/c/randomSOCPProb.c $(OUT)/libscsdir.a
+$(OUT)/demo_SOCP_direct: examples/c/randomSOCPProb.c $(OUT)/libscsdir.a examples/c/problemUtils.h
 	mkdir -p $(OUT)
-	$(CC) $(CFLAGS) -o $@ $^ $(LDFLAGS)
+	$(CC) $(CFLAGS) -o $@ $< $(LDFLAGS) -lscsdir
 
-$(OUT)/demo_SOCP_indirect: examples/c/randomSOCPProb.c $(OUT)/libscsindir.a
+$(OUT)/demo_SOCP_indirect: examples/c/randomSOCPProb.c $(OUT)/libscsindir.a examples/c/problemUtils.h
 	mkdir -p $(OUT)
-	$(CC) $(CFLAGS) -o $@ $^ $(LDFLAGS)
+	$(CC) $(CFLAGS) -o $@ $< $(LDFLAGS) -lscsindir
 
 ## To compile dense versions: make dense
 ## Need to connect to blas lib (set USE_LAPACK = 1 in scs.mk)

--- a/scs.mk
+++ b/scs.mk
@@ -9,7 +9,9 @@ else
 LDFLAGS = -lm 
 endif
 
-CFLAGS = -g -Wall -pedantic -O3 -funroll-loops -Wstrict-prototypes -I. -Iinclude
+LDFLAGS += -L$(OUT)
+
+CFLAGS = -g -Wall -pedantic -O3 -funroll-loops -Wstrict-prototypes -I. -Iinclude -Iexamples/c
 
 LINSYS = linsys
 DIRSRC = $(LINSYS)/direct


### PR DESCRIPTION
Here's an alternative fix for the makefile which maintains the problemUtils.h dependency. I add 'out' to the library search path, which is maybe a bit weird, but perhaps we should compile the libraries to a directory like 'lib' and reserve 'out' for the demos?
