### PR TITLE
allow compile-time suffix for BLAS functions

### DIFF
--- a/src/cones.c
+++ b/src/cones.c
@@ -4,20 +4,19 @@
 #define CONE_TOL (1e-8)
 #define EXP_CONE_MAX_ITERS (100)
 
+/* Default to underscore for blas / lapack */
+#ifndef BLASSUFFIX
+#define BLASSUFFIX _
+#endif
+
 #ifdef LAPACK_LIB_FOUND
-/* underscore for blas / lapack, single or double precision */
-#ifdef NOBLASUNDERSCORE
+#define paste(pre,x,post) pre ## x ## post
+#define paste_(pre,x,post) paste(pre,x,post)
+/* single or double precision */
 #ifndef FLOAT
-#define BLAS(x) d ## x
+#define BLAS(x) paste_(d,x,BLASSUFFIX)
 #else
-#define BLAS(x) s ## x
-#endif
-#else
-#ifndef FLOAT
-#define BLAS(x) d ## x ## _
-#else
-#define BLAS(x) s ## x ## _
-#endif
+#define BLAS(x) paste_(s,x,BLASSUFFIX)
 #endif
 
 #ifdef MATLAB_MEX_FILE


### PR DESCRIPTION
For using scs in Julia (karanveerm/SCS.jl#1), we'd like to use the high-quality BLAS/LAPACK (openblas) that already ships with Julia. For a number of technical reasons, Julia appends its own suffix to BLAS functions, e.g., `daxpy_64_`. This change lets us pass in the suffix with `-DBLASSUFFIX=_64_`. Also, `-DNOBLASUNDERSCORE` is replaced by `-DBLASSUFFIX=`

CC @tkelman
