### PR TITLE
acquire GIL for scs_printf in Python

### DIFF
--- a/include/glbopts.h
+++ b/include/glbopts.h
@@ -17,7 +17,11 @@ extern "C" {
 #elif defined PYTHON
 #include <Python.h>
 #include <stdlib.h>
-#define scs_printf  PySys_WriteStdout
+#define scs_printf(...) {\
+    PyGILState_STATE gilstate = PyGILState_Ensure();\
+    PySys_WriteStdout(__VA_ARGS__);\
+    PyGILState_Release(gilstate);\
+}
 #define _scs_free     free
 #define _scs_malloc   malloc
 #define _scs_calloc   calloc

--- a/linsys/direct/external/amd_global.c
+++ b/linsys/direct/external/amd_global.c
@@ -72,8 +72,4 @@ void *(*amd_calloc) (size_t, size_t) = SCS_NULL ;
  * can then be enabled at run-time by setting amd_printf to a non-SCS_NULL function.
  */
 
-#ifndef NPRINT
-int (*amd_printf) (const char *, ...) = scs_printf ;
-#else
 int (*amd_printf) (const char *, ...) = SCS_NULL ;
-#endif


### PR DESCRIPTION
I'd like to release the GIL in Python when calling SCS to allow for easy multithreaded parallelism. While the GIL can be released while SCS is doing much of its computation, SCS needs to reacquire the GIL if it wants to print with `PySys_WriteStdout`. 

I do this by changing `scs_printf` to a macro, and remove the one place where a function is expected in `amd_global.c`. I'm guessing this could also be done with a wrapping function instead, so that `amd_global.c` wouldn't need modification, but a macro seemed simpler to me.

Let me know if you think there's a better way to do this.

Here's the associated Cython mailing list question: https://groups.google.com/forum/#!topic/cython-users/9ovadiKRuoY