### PR TITLE
build with OpenMP by default in setup.py

### DIFF
--- a/linsys/common.c
+++ b/linsys/common.c
@@ -239,7 +239,7 @@ void _accumByAtrans(scs_int n, scs_float *Ax, scs_int *Ai, scs_int *Ap,
     timer multByAtransTimer;
     tic(&multByAtransTimer);
 #endif
-#ifdef OPENMP
+#ifdef _OPENMP
 #pragma omp parallel for private(p, c1, c2, yj)
 #endif
     for (j = 0; j < n; j++) {

--- a/src/cones.c
+++ b/src/cones.c
@@ -695,7 +695,7 @@ scs_int projDualCone(scs_float *x, const Cone *k, ConeWork *c,
          * \Pi_C^*(y) = y + \Pi_C(-y)
          */
         scaleArray(&(x[count]), -1, 3 * k->ep); /* x = -x; */
-#ifdef OPENMP
+#ifdef _OPENMP
 #pragma omp parallel for private(r, s, t, idx)
 #endif
         for (i = 0; i < k->ep; ++i) {
@@ -719,7 +719,7 @@ scs_int projDualCone(scs_float *x, const Cone *k, ConeWork *c,
 
     if (k->ed) {
 /* exponential cone: */
-#ifdef OPENMP
+#ifdef _OPENMP
 #pragma omp parallel for
 #endif
         for (i = 0; i < k->ed; ++i) {
@@ -736,7 +736,7 @@ scs_int projDualCone(scs_float *x, const Cone *k, ConeWork *c,
         scs_float v[3];
         scs_int idx;
         /* don't use openmp for power cone
-        ifdef OPENMP
+        ifdef _OPENMP
         pragma omp parallel for private(v, idx)
         endif
         */


### PR DESCRIPTION
This change removes the OpenMP compilation flag from the setup.py installer. The installer now attempts to build with OpenMP -- if the compiler being used does not implement the specification, then the installation will proceed without OpenMP. The installer still does not handle Windows, however.