### PR TITLE
Allow linsys solvers to define their own normalization routes.

### DIFF
--- a/linsys/common.c
+++ b/linsys/common.c
@@ -101,8 +101,8 @@ static void print_a_matrix(const ScsMatrix *A) {
 }
 #endif
 
-void SCS(normalize_a)(ScsMatrix *A, const ScsSettings *stgs, const ScsCone *k,
-                      ScsScaling *scal) {
+void SCS(_normalize_a)(ScsMatrix *A, const ScsSettings *stgs,
+                       const ScsCone *k, ScsScaling *scal) {
   DEBUG_FUNC
   scs_float *D = (scs_float *)scs_malloc(A->m * sizeof(scs_float));
   scs_float *E = (scs_float *)scs_malloc(A->n * sizeof(scs_float));
@@ -217,8 +217,8 @@ void SCS(normalize_a)(ScsMatrix *A, const ScsSettings *stgs, const ScsCone *k,
   RETURN;
 }
 
-void SCS(un_normalize_a)(ScsMatrix *A, const ScsSettings *stgs,
-                         const ScsScaling *scal) {
+void SCS(_un_normalize_a)(ScsMatrix *A, const ScsSettings *stgs,
+                          const ScsScaling *scal) {
   scs_int i, j;
   scs_float *D = scal->D;
   scs_float *E = scal->E;

--- a/linsys/common.h
+++ b/linsys/common.h
@@ -15,6 +15,10 @@ void SCS(_accum_by_atrans)(scs_int n, scs_float *Ax, scs_int *Ai, scs_int *Ap,
                            const scs_float *x, scs_float *y);
 void SCS(_accum_by_a)(scs_int n, scs_float *Ax, scs_int *Ai, scs_int *Ap,
                       const scs_float *x, scs_float *y);
+void SCS(_normalize_a)(ScsMatrix *A, const ScsSettings *stgs,
+                       const ScsCone *k, ScsScaling *scal);
+void SCS(_un_normalize_a)(ScsMatrix *A, const ScsSettings *stgs,
+                          const ScsScaling *scal);
 scs_float SCS(cumsum)(scs_int *p, scs_int *c, scs_int n);
 
 #ifdef __cplusplus

--- a/linsys/direct/private.c
+++ b/linsys/direct/private.c
@@ -371,3 +371,13 @@ scs_int SCS(solve_lin_sys)(const ScsMatrix *A, const ScsSettings *stgs,
 #endif
   return 0;
 }
+
+void SCS(normalize_a)(ScsMatrix *A, const ScsSettings *stgs,
+                       const ScsCone *k, ScsScaling *scal) {
+  SCS(_normalize_a)(A, stgs, k, scal);
+}
+
+void SCS(un_normalize_a)(ScsMatrix *A, const ScsSettings *stgs,
+                         const ScsScaling *scal) {
+  SCS(_un_normalize_a)(A, stgs, scal);
+}

--- a/linsys/gpu/private.c
+++ b/linsys/gpu/private.c
@@ -438,6 +438,16 @@ scs_int SCS(solve_lin_sys)(const ScsMatrix *A, const ScsSettings *stgs,
   return 0;
 }
 
+void SCS(normalize_a)(ScsMatrix *A, const ScsSettings *stgs,
+                      const ScsCone *k, ScsScaling *scal) {
+  SCS(_normalize_a)(A, stgs, k, scal);
+}
+
+void SCS(un_normalize_a)(ScsMatrix *A, const ScsSettings *stgs,
+                         const ScsScaling *scal) {
+  SCS(_un_normalize_a)(A, stgs, scal);
+}
+
 #ifdef __cplusplus
 }
 #endif

--- a/linsys/indirect/private.c
+++ b/linsys/indirect/private.c
@@ -263,3 +263,13 @@ scs_int SCS(solve_lin_sys)(const ScsMatrix *A, const ScsSettings *stgs,
 #endif
   return 0;
 }
+
+void SCS(normalize_a)(ScsMatrix *A, const ScsSettings *stgs,
+                       const ScsCone *k, ScsScaling *scal) {
+  SCS(_normalize_a)(A, stgs, k, scal);
+}
+
+void SCS(un_normalize_a)(ScsMatrix *A, const ScsSettings *stgs,
+                         const ScsScaling *scal) {
+  SCS(_un_normalize_a)(A, stgs, scal);
+}


### PR DESCRIPTION
Before this PR, `SCS(normalize_a)` and `SCS(un_normalize_a)` were defined in `linsys/common.c` and are unable to be set by a user-provided linsys solver. This PR renames these methods and accesses them from the existing solvers.