### PR TITLE
Update deprecated CUDA functions

### DIFF
--- a/linsys/gpu/gpu.c
+++ b/linsys/gpu/gpu.c
@@ -1,65 +1,79 @@
 #include "gpu.h"
 
 void SCS(_accum_by_atrans_gpu)(const ScsGpuMatrix *Ag, const scs_float *x,
-                               scs_float *y, cusparseHandle_t cusparse_handle) {
+                               scs_float *y, cusparseHandle_t cusparse_handle,
+                               size_t *buffer_size, void **buffer) {
   /* y += A'*x
      x and y MUST be on GPU already
   */
   const scs_float onef = 1.0;
-  cusparseDnVecDescr_t dnVecX = SCS_NULL, dnVecY = SCS_NULL;
-  size_t bufferSize = 0;
-  void *tmpBuffer = SCS_NULL;
+  cusparseDnVecDescr_t dn_vec_x = SCS_NULL, dn_vec_y = SCS_NULL;
+  size_t new_buffer_size = 0;
 
-  cusparseCreateDnVec(&dnVecX, Ag->m, (void *) x, SCS_CUDA_FLOAT);
-  cusparseCreateDnVec(&dnVecY, Ag->n, (void *) y, SCS_CUDA_FLOAT);
+  cusparseCreateDnVec(&dn_vec_x, Ag->m, (void *) x, SCS_CUDA_FLOAT);
+  cusparseCreateDnVec(&dn_vec_y, Ag->n, (void *) y, SCS_CUDA_FLOAT);
 
   CUSPARSE_GEN(SpMV_bufferSize)
   (cusparse_handle, CUSPARSE_OPERATION_NON_TRANSPOSE,
-    &onef, Ag->descr, dnVecX, &onef, dnVecY,
+    &onef, Ag->descr, dn_vec_x, &onef, dn_vec_y,
     SCS_CUDA_FLOAT, SCS_CSRMV_ALG,
-    &bufferSize);
-  cudaMalloc(&tmpBuffer, bufferSize); 
+    &new_buffer_size);
+
+  if (new_buffer_size > *buffer_size) {
+    if (*buffer != SCS_NULL) {
+      cudaFree(*buffer);
+    }
+    cudaMalloc(buffer, *buffer_size);
+    *buffer_size = new_buffer_size;
+  }
+
   CUSPARSE_GEN(SpMV)
   (cusparse_handle, CUSPARSE_OPERATION_NON_TRANSPOSE,
-    &onef, Ag->descr, dnVecX, &onef, dnVecY,
+    &onef, Ag->descr, dn_vec_x, &onef, dn_vec_y,
     SCS_CUDA_FLOAT, SCS_CSRMV_ALG,
-    tmpBuffer);
+    buffer);
 
-  cusparseDestroyDnVec(dnVecX);
-  cusparseDestroyDnVec(dnVecY);
-  cudaFree(tmpBuffer);
+  cusparseDestroyDnVec(dn_vec_x);
+  cusparseDestroyDnVec(dn_vec_y);
 }
 
 void SCS(_accum_by_a_gpu)(const ScsGpuMatrix *Ag, const scs_float *x,
-                          scs_float *y, cusparseHandle_t cusparse_handle) {
+                          scs_float *y, cusparseHandle_t cusparse_handle,
+                          size_t *buffer_size, void **buffer) {
   /* y += A*x
      x and y MUST be on GPU already
    */
   const scs_float onef = 1.0;
-  cusparseDnVecDescr_t dnVecX = SCS_NULL, dnVecY = SCS_NULL;
-  size_t bufferSize = 0;
-  void *tmpBuffer = SCS_NULL;
+  cusparseDnVecDescr_t dn_vec_x = SCS_NULL, dn_vec_y = SCS_NULL;
+  size_t new_buffer_size = 0;
 
   /* The A matrix idx pointers must be ORDERED */
 
-  cusparseCreateDnVec(&dnVecX, Ag->n, (void *) x, SCS_CUDA_FLOAT);
-  cusparseCreateDnVec(&dnVecY, Ag->m, (void *) y, SCS_CUDA_FLOAT);
+  cusparseCreateDnVec(&dn_vec_x, Ag->n, (void *) x, SCS_CUDA_FLOAT);
+  cusparseCreateDnVec(&dn_vec_y, Ag->m, (void *) y, SCS_CUDA_FLOAT);
 
   CUSPARSE_GEN(SpMV_bufferSize)
   (cusparse_handle, CUSPARSE_OPERATION_TRANSPOSE,
-    &onef, Ag->descr, dnVecX, &onef, dnVecY,
+    &onef, Ag->descr, dn_vec_x, &onef, dn_vec_y,
     SCS_CUDA_FLOAT, SCS_CSRMV_ALG,
-    &bufferSize);
-  cudaMalloc(&tmpBuffer, bufferSize);
+    &new_buffer_size);
+
+  if (new_buffer_size > *buffer_size) {
+    if (*buffer != SCS_NULL) {
+      cudaFree(*buffer);
+    }
+    cudaMalloc(buffer, *buffer_size);
+    *buffer_size = new_buffer_size;
+  }
+
   CUSPARSE_GEN(SpMV)
   (cusparse_handle, CUSPARSE_OPERATION_TRANSPOSE,
-    &onef, Ag->descr, dnVecX, &onef, dnVecY,
+    &onef, Ag->descr, dn_vec_x, &onef, dn_vec_y,
     SCS_CUDA_FLOAT, SCS_CSRMV_ALG,
-    tmpBuffer);
+    buffer);
 
-  cusparseDestroyDnVec(dnVecX);
-  cusparseDestroyDnVec(dnVecY);
-  cudaFree(tmpBuffer);
+  cusparseDestroyDnVec(dn_vec_x);
+  cusparseDestroyDnVec(dn_vec_y);
 }
 
 void SCS(free_gpu_matrix)(ScsGpuMatrix *A) {

--- a/linsys/gpu/gpu.c
+++ b/linsys/gpu/gpu.c
@@ -13,13 +13,13 @@ void SCS(_accum_by_atrans_gpu)(const ScsGpuMatrix *Ag, const scs_float *x,
   cusparseCreateDnVec(&dnVecX, Ag->m, (void *) x, SCS_CUDA_FLOAT);
   cusparseCreateDnVec(&dnVecY, Ag->n, (void *) y, SCS_CUDA_FLOAT);
 
-  cusparseSpMV_bufferSize
+  CUSPARSE_GEN(SpMV_bufferSize)
   (cusparse_handle, CUSPARSE_OPERATION_NON_TRANSPOSE,
     &onef, Ag->descr, dnVecX, &onef, dnVecY,
     SCS_CUDA_FLOAT, SCS_CSRMV_ALG,
     &bufferSize);
   cudaMalloc(&tmpBuffer, bufferSize); 
-  cusparseSpMV
+  CUSPARSE_GEN(SpMV)
   (cusparse_handle, CUSPARSE_OPERATION_NON_TRANSPOSE,
     &onef, Ag->descr, dnVecX, &onef, dnVecY,
     SCS_CUDA_FLOAT, SCS_CSRMV_ALG,
@@ -45,13 +45,13 @@ void SCS(_accum_by_a_gpu)(const ScsGpuMatrix *Ag, const scs_float *x,
   cusparseCreateDnVec(&dnVecX, Ag->n, (void *) x, SCS_CUDA_FLOAT);
   cusparseCreateDnVec(&dnVecY, Ag->m, (void *) y, SCS_CUDA_FLOAT);
 
-  cusparseSpMV_bufferSize
+  CUSPARSE_GEN(SpMV_bufferSize)
   (cusparse_handle, CUSPARSE_OPERATION_TRANSPOSE,
     &onef, Ag->descr, dnVecX, &onef, dnVecY,
     SCS_CUDA_FLOAT, SCS_CSRMV_ALG,
     &bufferSize);
   cudaMalloc(&tmpBuffer, bufferSize);
-  cusparseSpMV
+  CUSPARSE_GEN(SpMV)
   (cusparse_handle, CUSPARSE_OPERATION_TRANSPOSE,
     &onef, Ag->descr, dnVecX, &onef, dnVecY,
     SCS_CUDA_FLOAT, SCS_CSRMV_ALG,

--- a/linsys/gpu/gpu.c
+++ b/linsys/gpu/gpu.c
@@ -6,9 +6,28 @@ void SCS(_accum_by_atrans_gpu)(const ScsGpuMatrix *Ag, const scs_float *x,
      x and y MUST be on GPU already
   */
   const scs_float onef = 1.0;
-  CUSPARSE(csrmv)
-  (cusparse_handle, CUSPARSE_OPERATION_NON_TRANSPOSE, Ag->n, Ag->m, Ag->Annz,
-   &onef, Ag->descr, Ag->x, Ag->p, Ag->i, x, &onef, y);
+  cusparseDnVecDescr_t dnVecX = SCS_NULL, dnVecY = SCS_NULL;
+  size_t bufferSize = 0;
+  void *tmpBuffer = SCS_NULL;
+
+  cusparseCreateDnVec(&dnVecX, Ag->m, (void *) x, SCS_CUDA_FLOAT);
+  cusparseCreateDnVec(&dnVecY, Ag->n, (void *) y, SCS_CUDA_FLOAT);
+
+  cusparseSpMV_bufferSize
+  (cusparse_handle, CUSPARSE_OPERATION_NON_TRANSPOSE,
+    &onef, Ag->descr, dnVecX, &onef, dnVecY,
+    SCS_CUDA_FLOAT, SCS_CSRMV_ALG,
+    &bufferSize);
+  cudaMalloc(&tmpBuffer, bufferSize); 
+  cusparseSpMV
+  (cusparse_handle, CUSPARSE_OPERATION_NON_TRANSPOSE,
+    &onef, Ag->descr, dnVecX, &onef, dnVecY,
+    SCS_CUDA_FLOAT, SCS_CSRMV_ALG,
+    tmpBuffer);
+
+  cusparseDestroyDnVec(dnVecX);
+  cusparseDestroyDnVec(dnVecY);
+  cudaFree(tmpBuffer);
 }
 
 void SCS(_accum_by_a_gpu)(const ScsGpuMatrix *Ag, const scs_float *x,
@@ -17,17 +36,37 @@ void SCS(_accum_by_a_gpu)(const ScsGpuMatrix *Ag, const scs_float *x,
      x and y MUST be on GPU already
    */
   const scs_float onef = 1.0;
+  cusparseDnVecDescr_t dnVecX = SCS_NULL, dnVecY = SCS_NULL;
+  size_t bufferSize = 0;
+  void *tmpBuffer = SCS_NULL;
+
   /* The A matrix idx pointers must be ORDERED */
-  CUSPARSE(csrmv)
-  (cusparse_handle, CUSPARSE_OPERATION_TRANSPOSE, Ag->n, Ag->m, Ag->Annz, &onef,
-   Ag->descr, Ag->x, Ag->p, Ag->i, x, &onef, y);
+
+  cusparseCreateDnVec(&dnVecX, Ag->n, (void *) x, SCS_CUDA_FLOAT);
+  cusparseCreateDnVec(&dnVecY, Ag->m, (void *) y, SCS_CUDA_FLOAT);
+
+  cusparseSpMV_bufferSize
+  (cusparse_handle, CUSPARSE_OPERATION_TRANSPOSE,
+    &onef, Ag->descr, dnVecX, &onef, dnVecY,
+    SCS_CUDA_FLOAT, SCS_CSRMV_ALG,
+    &bufferSize);
+  cudaMalloc(&tmpBuffer, bufferSize);
+  cusparseSpMV
+  (cusparse_handle, CUSPARSE_OPERATION_TRANSPOSE,
+    &onef, Ag->descr, dnVecX, &onef, dnVecY,
+    SCS_CUDA_FLOAT, SCS_CSRMV_ALG,
+    tmpBuffer);
+
+  cusparseDestroyDnVec(dnVecX);
+  cusparseDestroyDnVec(dnVecY);
+  cudaFree(tmpBuffer);
 }
 
 void SCS(free_gpu_matrix)(ScsGpuMatrix *A) {
   cudaFree(A->x);
   cudaFree(A->i);
   cudaFree(A->p);
-  cusparseDestroyMatDescr(A->descr);
+  cusparseDestroySpMat(A->descr);
 }
 
 void SCS(normalize_a)(ScsMatrix *A, const ScsSettings *stgs, const ScsCone *k,

--- a/linsys/gpu/gpu.h
+++ b/linsys/gpu/gpu.h
@@ -90,12 +90,12 @@ typedef struct SCS_GPU_A_DATA_MATRIX {
   cusparseSpMatDescr_t descr;
 } ScsGpuMatrix;
 
-void SCS(_accum_by_atrans_gpu)(const ScsGpuMatrix *A, const scs_float *x,
-                               scs_float *y, cusparseHandle_t cusparse_handle,
+void SCS(_accum_by_atrans_gpu)(const ScsGpuMatrix *A, const cusparseDnVecDescr_t x,
+                               cusparseDnVecDescr_t y, cusparseHandle_t cusparse_handle,
                                size_t *buffer_size, void **buffer);
 
-void SCS(_accum_by_a_gpu)(const ScsGpuMatrix *A, const scs_float *x,
-                          scs_float *y, cusparseHandle_t cusparse_handle,
+void SCS(_accum_by_a_gpu)(const ScsGpuMatrix *A, const cusparseDnVecDescr_t x,
+                          cusparseDnVecDescr_t y, cusparseHandle_t cusparse_handle,
                           size_t *buffer_size, void **buffer);
 
 void SCS(free_gpu_matrix)(ScsGpuMatrix *A);

--- a/linsys/gpu/gpu.h
+++ b/linsys/gpu/gpu.h
@@ -91,10 +91,12 @@ typedef struct SCS_GPU_A_DATA_MATRIX {
 } ScsGpuMatrix;
 
 void SCS(_accum_by_atrans_gpu)(const ScsGpuMatrix *A, const scs_float *x,
-                               scs_float *y, cusparseHandle_t cusparse_handle);
+                               scs_float *y, cusparseHandle_t cusparse_handle,
+                               size_t *buffer_size, void **buffer);
 
 void SCS(_accum_by_a_gpu)(const ScsGpuMatrix *A, const scs_float *x,
-                          scs_float *y, cusparseHandle_t cusparse_handle);
+                          scs_float *y, cusparseHandle_t cusparse_handle,
+                          size_t *buffer_size, void **buffer);
 
 void SCS(free_gpu_matrix)(ScsGpuMatrix *A);
 

--- a/linsys/gpu/gpu.h
+++ b/linsys/gpu/gpu.h
@@ -34,6 +34,7 @@ extern "C" {
 #define CUBLAS(x) cublasS##x
 #define CUSPARSE(x) cusparseS##x
 #endif
+#define CUSPARSE_GEN(x) cusparse##x
 #else
 #ifndef SFLOAT
 #define CUBLAS(x) \
@@ -50,6 +51,9 @@ extern "C" {
   CUDA_CHECK_ERR;   \
   cusparseS##x
 #endif
+#define CUSPARSE_GEN(x) \
+  CUDA_CHECK_ERR;       \
+  cusparse##x
 #endif
 
 #ifndef SFLOAT

--- a/linsys/gpu/gpu.h
+++ b/linsys/gpu/gpu.h
@@ -52,6 +52,21 @@ extern "C" {
 #endif
 #endif
 
+#ifndef SFLOAT
+#define SCS_CUDA_FLOAT CUDA_R_64F
+#else
+#define SCS_CUDA_FLOAT CUDA_R_32F
+#endif
+
+#ifndef DLONG
+#define SCS_CUSPARSE_INDEX CUSPARSE_INDEX_32I
+#else
+#define SCS_CUSPARSE_INDEX CUSPARSE_INDEX_64I
+#endif
+
+#define SCS_CSRMV_ALG CUSPARSE_CSRMV_ALG1
+#define SCS_CSR2CSC_ALG CUSPARSE_CSR2CSC_ALG1
+
 /*
  CUDA matrix routines only for CSR, not CSC matrices:
     CSC             CSR             GPU     Mult
@@ -68,7 +83,7 @@ typedef struct SCS_GPU_A_DATA_MATRIX {
   scs_int m, n; /* m rows, n cols */
   scs_int Annz; /* num non-zeros in A matrix */
   /* CUDA */
-  cusparseMatDescr_t descr;
+  cusparseSpMatDescr_t descr;
 } ScsGpuMatrix;
 
 void SCS(_accum_by_atrans_gpu)(const ScsGpuMatrix *A, const scs_float *x,

--- a/linsys/gpu/indirect/private.h
+++ b/linsys/gpu/indirect/private.h
@@ -28,6 +28,9 @@ struct SCS_LIN_SYS_WORK {
   /* CUDA */
   cublasHandle_t cublas_handle;
   cusparseHandle_t cusparse_handle;
+  /* CUSPARSE buffer */
+  size_t buffer_size;
+  void *buffer;
 };
 
 #ifdef __cplusplus

--- a/linsys/gpu/indirect/private.h
+++ b/linsys/gpu/indirect/private.h
@@ -28,9 +28,11 @@ struct SCS_LIN_SYS_WORK {
   /* CUDA */
   cublasHandle_t cublas_handle;
   cusparseHandle_t cusparse_handle;
-  /* CUSPARSE buffer */
+  /* CUSPARSE */
   size_t buffer_size;
   void *buffer;
+  cusparseDnVecDescr_t dn_vec_m; /* Dense vector of length m */
+  cusparseDnVecDescr_t dn_vec_n; /* Dense vector of length n */
 };
 
 #ifdef __cplusplus


### PR DESCRIPTION
I found that in the GPU solver were used some of deprecated functions: [cusparseDcsrmv](https://docs.nvidia.com/cuda/archive/10.2/cusparse/#csrmv) and [cusparseDcsr2csc](https://docs.nvidia.com/cuda/archive/10.2/cusparse/#csr2csc). Since version 11.0 these functions [have been removed](https://docs.nvidia.com/cuda/archive/11.0/cuda-toolkit-release-notes/index.html#deprecated-features) from the CUDA Toolkit.

According to the NVIDIA documentation I replaced these functions with functions [cusparseSpMV](https://docs.nvidia.com/cuda/cusparse/index.html#cusparse-generic-function-spmv) and [cusparseCsr2cscEx2](https://docs.nvidia.com/cuda/cusparse/index.html#csr2cscEx2).

I also added a few new defines in the gpu.h file and changed the type of the sparse matrix descriptor in the SCS_GPU_A_DATA_MATRIX structure so that new functions can work with it.