### PR TITLE
Add CMake build-system

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -5,3 +5,4 @@ current_version = 2.1.3
 
 [bumpversion:file:include/glbopts.h]
 
+[bumpversion:file:CMakeLists.txt]

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,273 @@
+# CMakeLists.txt file for scs
+# This software may be modified and distributed under the terms of the MIT License
+
+cmake_minimum_required(VERSION 3.5)
+
+project(scs
+  LANGUAGES C
+  VERSION 2.1.3)
+
+# Defines the CMAKE_INSTALL_LIBDIR, CMAKE_INSTALL_BINDIR and many other useful macros.
+# See https://cmake.org/cmake/help/latest/module/GNUInstallDirs.html
+include(GNUInstallDirs)
+
+# Control where libraries and executables are placed during the build.
+# With the following settings executables are placed in <the top level of the
+# build tree>/bin and libraries/archives in <top level of the build tree>/lib.
+# This is particularly useful to run ctests on libraries built on Windows
+# machines: tests, which are executables, are placed in the same folders of
+# dlls, which are treated as executables as well, so that they can properly
+# find the libraries to run. This is a because of missing RPATH on Windows.
+set(CMAKE_RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/${CMAKE_INSTALL_BINDIR}")
+set(CMAKE_LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/${CMAKE_INSTALL_LIBDIR}")
+set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/${CMAKE_INSTALL_LIBDIR}")
+
+# To build shared libraries in Windows, we set CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS to TRUE.
+# See https://cmake.org/cmake/help/v3.4/variable/CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS.html
+# See https://blog.kitware.com/create-dlls-on-windows-without-declspec-using-new-cmake-export-all-feature/
+set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS ON)
+
+# Under MSVC, we set CMAKE_DEBUG_POSTFIX to "d" to add a trailing "d" to library
+# built in debug mode. In this Windows user can compile, build and install the
+# library in both Release and Debug configuration avoiding naming clashes in the
+# installation directories.
+if(MSVC)
+  set(CMAKE_DEBUG_POSTFIX "d")
+endif()
+
+# Build position independent code.
+# Position Independent Code (PIC) is commonly used for shared libraries so that
+# the same shared library code can be loaded in each program address space in a
+# location where it will not overlap with any other uses of such memory.
+# In particular, this option avoids problems occurring when a process wants to
+# load more than one shared library at the same virtual address.
+# Since shared libraries cannot predict where other shared libraries could be
+# loaded, this is an unavoidable problem with the traditional shared library
+# concept.
+# Generating position-independent code is often the default behavior for most
+# modern compilers.
+# Moreover linking a static library that is not built with PIC from a shared
+# library will fail on some compiler/architecture combinations.
+# Further details on PIC can be found here:
+# https://eli.thegreenplace.net/2011/11/03/position-independent-code-pic-in-shared-libraries/
+set(CMAKE_POSITION_INDEPENDENT_CODE ON)
+
+# Disable C and C++ compiler extensions.
+# C/CXX_EXTENSIONS are ON by default to allow the compilers to use extended
+# variants of the C/CXX language.
+# However, this could expose cross-platform bugs in user code or in the headers
+# of third-party dependencies and thus it is strongly suggested to turn
+# extensions off.
+set(CMAKE_C_EXTENSIONS OFF)
+set(CMAKE_CXX_EXTENSIONS OFF)
+list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
+
+### Options
+# Shared/Dynamic or Static library?
+option(BUILD_SHARED_LIBS "Build libraries as shared as opposed to static" ON)
+
+# Enable RPATH support for installed binaries and libraries
+include(AddInstallRPATHSupport)
+add_install_rpath_support(BIN_DIRS "${CMAKE_INSTALL_FULL_BINDIR}"
+  LIB_DIRS "${CMAKE_INSTALL_FULL_LIBDIR}"
+  INSTALL_NAME_DIR "${CMAKE_INSTALL_FULL_LIBDIR}"
+  USE_LINK_PATH)
+
+# Encourage user to specify a build type (e.g. Release, Debug, etc.), otherwise set it to Release.
+if(NOT CMAKE_CONFIGURATION_TYPES)
+  if(NOT CMAKE_BUILD_TYPE)
+    message(STATUS "Setting build type to 'Release' as none was specified.")
+    set_property(CACHE CMAKE_BUILD_TYPE PROPERTY VALUE "Release")
+  endif()
+endif()
+
+
+# Build test related commands?
+option(BUILD_TESTING "Create tests using CMake" OFF)
+if(BUILD_TESTING)
+  enable_testing()
+endif()
+
+### Some variables useful for sampling the building process
+# Note that the GPU profile is not compiled.
+set(LINSYS linsys)
+set(DIRSRC ${LINSYS}/cpu/direct)
+set(INDIRSRC ${LINSYS}/cpu/indirect)
+set(EXTERNAL ${LINSYS}/external)
+
+
+# Common source files
+set(${PROJECT_NAME}_SRC
+  src/aa.c
+  src/cones.c
+  src/ctrlc.c
+  src/linalg.c
+  src/normalize.c
+  src/rw.c
+  src/scs.c
+  src/scs_version.c
+  src/util.c
+  ${LINSYS}/amatrix.c)
+
+# Common header files
+set(${PROJECT_NAME}_HDR
+  include/aa.h
+  include/cones.h
+  include/ctrlc.h
+  include/glbopts.h
+  include/linalg.h
+  include/linsys.h
+  include/normalize.h
+  include/rw.h
+  include/scs.h
+  include/scs_blas.h
+  include/util.h
+  ${LINSYS}/amatrix.h)
+
+# get all the c file in amd/external
+file(GLOB ${PROJECT_NAME}_AMD_EXTERNAL_SRC
+  ${EXTERNAL}/amd/*.c
+  )
+
+# get all the h file in amd/external
+file(GLOB ${PROJECT_NAME}_AMD_EXTERNAL_HDR
+  ${EXTERNAL}/amd/*.h
+  )
+
+# get all the c file in amd/external
+file(GLOB ${PROJECT_NAME}_LDL_EXTERNAL_HDR
+  ${EXTERNAL}/qdldl/*.h
+  )
+
+### Direct method
+# Here we compile the direct method library
+set(${PROJECT_NAME}_DIRECT ${PROJECT_NAME}dir)
+add_library(${${PROJECT_NAME}_DIRECT}
+  ${${PROJECT_NAME}_HDR}
+  ${${PROJECT_NAME}_SRC}
+  ${DIRSRC}/private.c
+  ${DIRSRC}/private.h
+  ${EXTERNAL}/qdldl/qdldl.c
+  ${${PROJECT_NAME}_AMD_EXTERNAL_SRC}
+  ${${PROJECT_NAME}_AMD_EXTERNAL_HDR}
+  ${${PROJECT_NAME}_LDL_EXTERNAL_HDR})
+
+target_include_directories(${${PROJECT_NAME}_DIRECT} PRIVATE
+  "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/${EXTERNAL}/amd;${CMAKE_CURRENT_SOURCE_DIR}/${EXTERNAL}/qdldl;${CMAKE_CURRENT_SOURCE_DIR}/${DIRSRC};${CMAKE_CURRENT_SOURCE_DIR}/${LINSYS}>")
+
+target_include_directories(${${PROJECT_NAME}_DIRECT} PUBLIC
+  "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
+  "$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/scs>")
+
+# Compiled with blas and lapack, can solve LPs, SOCPs, SDPs, ECPs, and PCPs
+target_compile_definitions(${${PROJECT_NAME}_DIRECT} PRIVATE -DUSE_LAPACK)
+
+# The library depends on math (m) blas and lapack
+target_link_libraries(${${PROJECT_NAME}_DIRECT} PRIVATE
+  m
+  blas
+  lapack)
+
+# Set some properties
+set_target_properties(${${PROJECT_NAME}_DIRECT} PROPERTIES
+  VERSION ${scs_VERSION}
+  PUBLIC_HEADER "${${PROJECT_NAME}_HDR}")
+
+add_library(scs::${${PROJECT_NAME}_DIRECT} ALIAS ${${PROJECT_NAME}_DIRECT})
+
+# Install the library
+install(TARGETS ${${PROJECT_NAME}_DIRECT}
+  EXPORT  ${PROJECT_NAME}
+  COMPONENT runtime
+  LIBRARY          DESTINATION "${CMAKE_INSTALL_LIBDIR}"                            COMPONENT shlib
+  ARCHIVE          DESTINATION "${CMAKE_INSTALL_LIBDIR}"                            COMPONENT lib
+  RUNTIME          DESTINATION "${CMAKE_INSTALL_BINDIR}"                            COMPONENT bin
+  PUBLIC_HEADER    DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/scs")
+
+# Add the direct method to the set of the compiled targets
+set_property(GLOBAL APPEND PROPERTY scs_TARGETS ${${PROJECT_NAME}_DIRECT})
+
+### Indirect method
+# Here we compile the indirect method library
+set(${PROJECT_NAME}_INDIRECT ${PROJECT_NAME}indir)
+add_library(${${PROJECT_NAME}_INDIRECT}
+  ${${PROJECT_NAME}_HDR}
+  ${${PROJECT_NAME}_SRC}
+  ${INDIRSRC}/private.c
+  ${${${PROJECT_NAME}_INDIRECT}_HDR}
+  ${EXTERNAL}/qdldl/qdldl.c
+  ${${PROJECT_NAME}_AMD_EXTERNAL_SRC}
+  ${${PROJECT_NAME}_AMD_EXTERNAL_HDR}
+  ${${PROJECT_NAME}_LDL_EXTERNAL_SRC}
+  )
+
+
+target_include_directories(${${PROJECT_NAME}_INDIRECT} PRIVATE
+  "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/${EXTERNAL}/amd;${CMAKE_CURRENT_SOURCE_DIR}/${EXTERNAL}/qdldl;${CMAKE_CURRENT_SOURCE_DIR}/${INDIRSRC};${CMAKE_CURRENT_SOURCE_DIR}/${LINSYS}>")
+
+target_include_directories(${${PROJECT_NAME}_INDIRECT} PUBLIC
+  "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
+  "$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/scs>")
+
+# Compiled with blas and lapack, can solve LPs, SOCPs, SDPs, ECPs, and PCPs
+target_compile_definitions(${${PROJECT_NAME}_INDIRECT} PRIVATE -DUSE_LAPACK)
+
+# The library depends on math (m) blas and lapack
+target_link_libraries(${${PROJECT_NAME}_INDIRECT} PUBLIC
+  m
+  blas
+  lapack)
+
+# Set some properties
+set_target_properties(${${PROJECT_NAME}_INDIRECT} PROPERTIES
+  VERSION ${scs_VERSION}
+  PUBLIC_HEADER "${${${PROJECT_NAME}_INDIRECT}_HDR}")
+
+add_library(scs::${${PROJECT_NAME}_INDIRECT} ALIAS ${${PROJECT_NAME}_INDIRECT})
+
+# Install the library
+install(TARGETS ${${PROJECT_NAME}_INDIRECT}
+  EXPORT  ${PROJECT_NAME}
+  COMPONENT runtime
+  LIBRARY       DESTINATION "${CMAKE_INSTALL_LIBDIR}"                            COMPONENT shlib
+  ARCHIVE       DESTINATION "${CMAKE_INSTALL_LIBDIR}"                            COMPONENT lib
+  RUNTIME       DESTINATION "${CMAKE_INSTALL_BINDIR}"                            COMPONENT bin
+  PUBLIC_HEADER DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/scs")
+
+# Add the indirect method to the set of the compiled targets
+set_property(GLOBAL APPEND PROPERTY scs_TARGETS ${${PROJECT_NAME}_INDIRECT})
+
+### Install the .cmake file.
+# Thanks to thanks file it will be possible to link scs to consumer libraries
+include(InstallBasicPackageFiles)
+install_basic_package_files(${PROJECT_NAME}
+  NAMESPACE scs::
+  VERSION ${${PROJECT_NAME}_VERSION}
+  TARGETS_PROPERTY scs_TARGETS
+  COMPATIBILITY SameMajorVersion
+  VARS_PREFIX ${PROJECT_NAME}
+  NO_CHECK_REQUIRED_COMPONENTS_MACRO)
+
+### Add the tests
+if(BUILD_TESTING)
+  add_executable(run_tests_direct  test/run_tests.c)
+  target_link_libraries(run_tests_direct PRIVATE
+    scs::scsdir)
+  target_include_directories(run_tests_direct PRIVATE
+    "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/test;${CMAKE_CURRENT_SOURCE_DIR}/include;${CMAKE_CURRENT_SOURCE_DIR}/${LINSYS}>")
+
+  add_test(NAME run_tests_direct
+    COMMAND run_tests_direct
+    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
+
+  add_executable(run_tests_indirect  test/run_tests.c)
+  target_link_libraries(run_tests_indirect PRIVATE
+    scs::scsindir)
+  target_include_directories(run_tests_indirect PRIVATE
+    "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/test;${CMAKE_CURRENT_SOURCE_DIR}/include;${CMAKE_CURRENT_SOURCE_DIR}/${LINSYS}>")
+
+  add_test(NAME run_tests_indirect
+    COMMAND run_tests_indirect
+    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
+
+endif()

--- a/README.md
+++ b/README.md
@@ -238,7 +238,7 @@ make install
 You may also want to compile the tests. In this case when you configure the project,
 please call the following command
 ```
-cmake -DCMAKE_INSTALL_PREFIX:PATH=<custom-folder> -DBUILD_TESTING:ON ../
+cmake -DCMAKE_INSTALL_PREFIX:PATH=<custom-folder> -DBUILD_TESTING=ON ../
 make
 ctest
 ```

--- a/README.md
+++ b/README.md
@@ -220,3 +220,49 @@ two structs in `include/linsys.h` and plug it in.
 If you get an error like `cannot find -lblas` or `cannot find -llapack`, then
 you need to install blas and lapack and / or update your environment variables
 to point to the install locations.
+
+### Using SCS with cmake
+
+Thanks to [`CMake`](http://cmake.org) buildsystem, scs can be easily compiled
+and linked by other `CMake` projects. To use the `cmake` buld system please run
+the following commands:
+```
+cd scs
+mkdir build
+cd build
+cmake -DCMAKE_INSTALL_PREFIX:PATH=<custom-folder> ../
+make
+make install
+```
+
+You may also want to compile the tests. In this case when you configure the project,
+please call the following command
+```
+cmake -DCMAKE_INSTALL_PREFIX:PATH=<custom-folder> -DBUILD_TESTING:ON ../
+make
+ctest
+```
+
+By default the build-system will compile the library as `shared`. If you want to
+compile it as `static`, please call the following command when you configure the
+project
+```
+cmake -DCMAKE_INSTALL_PREFIX:PATH=<custom-folder> -BUILD_SHARED_LIBS=OFF ../
+make
+```
+
+The `cmake` build-system exports two CMake targets called `scs::scsdir` and
+`scs::scsindir` which can be imported using the `find_package` CMake command
+and used by calling `target_link_libraries` as in the following example:
+```cmake
+cmake_minimum_required(VERSION 3.0)
+project(myproject)
+find_package(scs REQUIRED)
+add_executable(example example.cpp)
+
+# To use the direct method
+target_link_libraries(example scs::scsdir)
+
+# To use the indirect method
+target_link_libraries(example scs::scsindir)
+```

--- a/cmake/AddInstallRPATHSupport.cmake
+++ b/cmake/AddInstallRPATHSupport.cmake
@@ -1,0 +1,237 @@
+# Distributed under the OSI-approved BSD 3-Clause License.  See accompanying
+# file Copyright.txt or https://cmake.org/licensing for details.
+
+#[=======================================================================[.rst:
+AddInstallRPATHSupport
+----------------------
+
+Add support to RPATH during installation to the project and the targets
+
+.. command:: add_install_rpath_support
+
+  Add support to RPATH during installation to the project::
+
+  .. code-block:: cmake
+
+    add_install_rpath_support([BIN_DIRS dir [dir]]
+                              [LIB_DIRS dir [dir]]
+                              [INSTALL_NAME_DIR [dir]]
+                              [DEPENDS condition [condition]]
+                              [USE_LINK_PATH])
+
+  Normally (depending on the platform) when you install a shared
+  library you can either specify its absolute path as the install name,
+  or leave just the library name itself. In the former case the library
+  will be correctly linked during run time by all executables and other
+  shared libraries, but it must not change its install location. This
+  is often the case for libraries installed in the system default
+  library directory (e.g. ``/usr/lib``).
+  In the latter case, instead, the library can be moved anywhere in the
+  file system but at run time the dynamic linker must be able to find
+  it. This is often accomplished by setting environmental variables
+  (i.e. ``LD_LIBRARY_PATH`` on Linux).
+  This procedure is usually not desirable for two main reasons:
+
+  - by setting the variable you are changing the default behaviour
+    of the dynamic linker thus potentially breaking executables (not as
+    destructive as ``LD_PRELOAD``)
+  - the variable will be used only by applications spawned by the shell
+    and not by other processes.
+
+  RPATH aims in solving the issues introduced by the second
+  installation method. Using run-path dependent libraries you can
+  create a directory structure containing executables and dependent
+  libraries that users can relocate without breaking it.
+  A run-path dependent library is a dependent library whose complete
+  install name is not known when the library is created.
+  Instead, the library specifies that the dynamic loader must resolve
+  the library’s install name when it loads the executable that depends
+  on the library. The executable or the other shared library will
+  hardcode in the binary itself the additional search directories
+  to be passed to the dynamic linker. This works great in conjunction
+  with relative paths.
+  This command will enable support to RPATH to your project.
+  It will enable the following things:
+
+   - If the project builds shared libraries it will generate a run-path
+     enabled shared library, i.e. its install name will be resolved
+     only at run time.
+   - In all cases (building executables and/or shared libraries)
+     dependent shared libraries with RPATH support will have their name
+     resolved only at run time, by embedding the search path directly
+     into the built binary.
+
+  The command has the following parameters:
+
+  Options:
+   - ``USE_LINK_PATH``: if passed the command will automatically adds to
+     the RPATH the path to all the dependent libraries.
+
+  Arguments:
+   - ``BIN_DIRS`` list of directories when the targets (executable and
+     plugins) will be installed.
+   - ``LIB_DIRS`` list of directories to be added to the RPATH. These
+     directories will be added "relative" w.r.t. the ``BIN_DIRS`` and
+     ``LIB_DIRS``.
+   - ``INSTALL_NAME_DIR`` directory where the libraries will be installed.
+     This variable will be used only if ``CMAKE_SKIP_RPATH`` or
+     ``CMAKE_SKIP_INSTALL_RPATH`` is set to ``TRUE`` as it will set the
+     ``INSTALL_NAME_DIR`` on all targets
+   - ``DEPENDS`` list of conditions that should be ``TRUE`` to enable
+     RPATH, for example ``FOO; NOT BAR``.
+
+  Note: see https://gitlab.kitware.com/cmake/cmake/issues/16589 for further
+  details.
+
+.. command:: target_append_install_rpath
+
+  Add extra paths to RPATH for a specific target::
+
+  .. code-block:: cmake
+
+    target_append_install_rpath(<target>
+                                <INSTALL_DESTINATION destination>
+                                [LIB_DIRS dir [dir]]
+                                [DEPENDS condition [condition]])
+
+  Arguments:
+   - ``INSTALL_DESTINATION`` path where the target will be installed.
+   - ``LIB_DIRS`` list of directories to be added to the RPATH. These
+     directories will be added "relative" w.r.t. the ``INSTALL_DESTINATION``.
+   - ``DEPENDS`` list of conditions that should be ``TRUE`` to enable
+     RPATH, for example ``FOO; NOT BAR``.
+
+#]=======================================================================]
+
+include(CMakeParseArguments)
+
+
+macro(__AddInstallRPATHSupport_GET_SYSTEM_LIB_DIRS _var)
+  # Find system implicit lib directories
+  set(${_var} ${CMAKE_PLATFORM_IMPLICIT_LINK_DIRECTORIES})
+  if(EXISTS "/etc/debian_version") # is this a debian system ?
+    if(CMAKE_LIBRARY_ARCHITECTURE)
+      list(APPEND ${_var} "/lib/${CMAKE_LIBRARY_ARCHITECTURE}"
+                          "/usr/lib/${CMAKE_LIBRARY_ARCHITECTURE}")
+    endif()
+  endif()
+endmacro()
+
+
+macro(__AddInstallRPATHSupport_APPEND_RELATIVE_RPATH _var _bin_dir _lib_dir)
+  file(RELATIVE_PATH _rel_path ${_bin_dir} ${_lib_dir})
+  if (${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
+    list(APPEND ${_var} "@loader_path/${_rel_path}")
+  else()
+    list(APPEND ${_var} "\$ORIGIN/${_rel_path}")
+  endif()
+endmacro()
+
+
+
+function(ADD_INSTALL_RPATH_SUPPORT)
+
+  set(_options USE_LINK_PATH)
+  set(_oneValueArgs INSTALL_NAME_DIR)
+  set(_multiValueArgs BIN_DIRS
+                      LIB_DIRS
+                      DEPENDS)
+
+  cmake_parse_arguments(_ARS "${_options}"
+                             "${_oneValueArgs}"
+                             "${_multiValueArgs}"
+                             "${ARGN}")
+
+  # if either RPATH or INSTALL_RPATH is disabled
+  # and the INSTALL_NAME_DIR variable is set, then hardcode the install name
+  if(CMAKE_SKIP_RPATH OR CMAKE_SKIP_INSTALL_RPATH)
+    if(DEFINED _ARS_INSTALL_NAME_DIR)
+      set(CMAKE_INSTALL_NAME_DIR ${_ARS_INSTALL_NAME_DIR} PARENT_SCOPE)
+    endif()
+  endif()
+
+  if (CMAKE_SKIP_RPATH OR (CMAKE_SKIP_INSTALL_RPATH AND CMAKE_SKIP_BUILD_RPATH))
+    return()
+  endif()
+
+
+  set(_rpath_available 1)
+  if(DEFINED _ARS_DEPENDS)
+    foreach(_dep ${_ARS_DEPENDS})
+      string(REGEX REPLACE " +" ";" _dep "${_dep}")
+      if(NOT (${_dep}))
+        set(_rpath_available 0)
+      endif()
+    endforeach()
+  endif()
+
+  if(_rpath_available)
+
+    # Enable RPATH on OSX.
+    set(CMAKE_MACOSX_RPATH TRUE PARENT_SCOPE)
+
+    __AddInstallRPATHSupport_get_system_lib_dirs(_system_lib_dirs)
+
+    # This is relative RPATH for libraries built in the same project
+    foreach(lib_dir ${_ARS_LIB_DIRS})
+      list(FIND _system_lib_dirs "${lib_dir}" isSystemDir)
+      if("${isSystemDir}" STREQUAL "-1")
+        foreach(bin_dir ${_ARS_LIB_DIRS} ${_ARS_BIN_DIRS})
+          __AddInstallRPATHSupport_append_relative_rpath(CMAKE_INSTALL_RPATH ${bin_dir} ${lib_dir})
+        endforeach()
+      endif()
+    endforeach()
+    if(NOT "${CMAKE_INSTALL_RPATH}" STREQUAL "")
+      list(REMOVE_DUPLICATES CMAKE_INSTALL_RPATH)
+    endif()
+    set(CMAKE_INSTALL_RPATH ${CMAKE_INSTALL_RPATH} PARENT_SCOPE)
+
+    # add the automatically determined parts of the RPATH
+    # which point to directories outside the build tree to the install RPATH
+    set(CMAKE_INSTALL_RPATH_USE_LINK_PATH ${_ARS_USE_LINK_PATH} PARENT_SCOPE)
+
+  endif()
+
+endfunction()
+
+
+function(TARGET_APPEND_INSTALL_RPATH _target)
+  set(_options )
+  set(_oneValueArgs INSTALL_DESTINATION)
+  set(_multiValueArgs LIB_DIRS
+                      DEPENDS)
+
+  if (CMAKE_SKIP_RPATH OR (CMAKE_SKIP_INSTALL_RPATH AND CMAKE_SKIP_BUILD_RPATH))
+    return()
+  endif()
+
+  cmake_parse_arguments(_ARS "${_options}"
+                             "${_oneValueArgs}"
+                             "${_multiValueArgs}"
+                             "${ARGN}")
+
+  set(_rpath_available 1)
+  if(DEFINED _ARS_DEPENDS)
+    foreach(_dep ${_ARS_DEPENDS})
+      string(REGEX REPLACE " +" ";" _dep "${_dep}")
+      if(NOT (${_dep}))
+        set(_rpath_available 0)
+      endif()
+    endforeach()
+  endif()
+
+  if(_rpath_available)
+
+    __AddInstallRPATHSupport_get_system_lib_dirs(_system_lib_dirs)
+
+    get_target_property(_current_rpath ${_target} INSTALL_RPATH)
+    foreach(lib_dir ${_ARS_LIB_DIRS})
+      list(FIND _system_lib_dirs "${lib_dir}" isSystemDir)
+      if("${isSystemDir}" STREQUAL "-1")
+        __AddInstallRPATHSupport_append_relative_rpath(_current_rpath ${_ARS_INSTALL_DESTINATION} ${lib_dir})
+      endif()
+    endforeach()
+    set_target_properties(${_target} PROPERTIES INSTALL_RPATH "${_current_rpath}")
+  endif()
+
+endfunction()

--- a/cmake/AddUninstallTarget.cmake
+++ b/cmake/AddUninstallTarget.cmake
@@ -1,0 +1,70 @@
+#.rst:
+# AddUninstallTarget
+# ------------------
+#
+# Add the "uninstall" target for your project::
+#
+#   include(AddUninstallTarget)
+#
+#
+# will create a file cmake_uninstall.cmake in the build directory and add a
+# custom target uninstall that will remove the files installed by your package
+# (using install_manifest.txt)
+
+#=============================================================================
+# Copyright 2008-2013 Kitware, Inc.
+# Copyright 2013 Istituto Italiano di Tecnologia (IIT)
+#   Authors: Daniele E. Domenichelli <daniele.domenichelli@iit.it>
+#
+# Distributed under the OSI-approved BSD License (the "License");
+# see accompanying file Copyright.txt for details.
+#
+# This software is distributed WITHOUT ANY WARRANTY; without even the
+# implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See the License for more information.
+#=============================================================================
+# (To distribute this file outside of CMake, substitute the full
+#  License text for the above reference.)
+
+
+if(DEFINED __ADD_UNINSTALL_TARGET_INCLUDED)
+  return()
+endif()
+set(__ADD_UNINSTALL_TARGET_INCLUDED TRUE)
+
+
+set(_filename ${CMAKE_CURRENT_BINARY_DIR}/cmake_uninstall.cmake)
+
+file(WRITE ${_filename}
+"if(NOT EXISTS \"${CMAKE_CURRENT_BINARY_DIR}/install_manifest.txt\")
+    message(WARNING \"Cannot find install manifest: \\\"${CMAKE_CURRENT_BINARY_DIR}/install_manifest.txt\\\"\")
+    return()
+endif()
+
+file(READ \"${CMAKE_CURRENT_BINARY_DIR}/install_manifest.txt\" files)
+string(STRIP \"\${files}\" files)
+string(REGEX REPLACE \"\\n\" \";\" files \"\${files}\")
+list(REVERSE files)
+foreach(file \${files})
+    message(STATUS \"Uninstalling: \$ENV{DESTDIR}\${file}\")
+    if(EXISTS \"\$ENV{DESTDIR}\${file}\")
+        execute_process(
+            COMMAND \${CMAKE_COMMAND} -E remove \"\$ENV{DESTDIR}\${file}\"
+            OUTPUT_VARIABLE rm_out
+            RESULT_VARIABLE rm_retval)
+        if(NOT \"\${rm_retval}\" EQUAL 0)
+            message(FATAL_ERROR \"Problem when removing \\\"\$ENV{DESTDIR}\${file}\\\"\")
+        endif()
+    else()
+        message(STATUS \"File \\\"\$ENV{DESTDIR}\${file}\\\" does not exist.\")
+    endif()
+endforeach(file)
+")
+
+if("${CMAKE_GENERATOR}" MATCHES "^(Visual Studio|Xcode)")
+    set(_uninstall "UNINSTALL")
+else()
+    set(_uninstall "uninstall")
+endif()
+add_custom_target(${_uninstall} COMMAND "${CMAKE_COMMAND}" -P "${_filename}")
+set_property(TARGET ${_uninstall} PROPERTY FOLDER "CMakePredefinedTargets")

--- a/cmake/InstallBasicPackageFiles.cmake
+++ b/cmake/InstallBasicPackageFiles.cmake
@@ -1,0 +1,677 @@
+#.rst:
+# InstallBasicPackageFiles
+# ------------------------
+#
+# A helper module to make your package easier to be found by other
+# projects.
+#
+#
+# .. command:: install_basic_package_files
+#
+# Create and install a basic version of cmake config files for your
+# project::
+#
+#  install_basic_package_files(<Name>
+#                              VERSION <version>
+#                              COMPATIBILITY <compatibility>
+#                              [EXPORT <export>] # (default = "<Name>")
+#                              [FIRST_TARGET <target1>] # (default = "<Name>")
+#                              [TARGETS <target1> <target2> ...]
+#                              [TARGETS_PROPERTY <property_name>]
+#                              [TARGETS_PROPERTIES <property1_name> <property2_name> ...]
+#                              [NO_SET_AND_CHECK_MACRO]
+#                              [NO_CHECK_REQUIRED_COMPONENTS_MACRO]
+#                              [VARS_PREFIX <prefix>] # (default = "<Name>")
+#                              [EXPORT_DESTINATION <destination>]
+#                              [INSTALL_DESTINATION <destination>]
+#                              [NAMESPACE <namespace>] # (default = "<Name>::")
+#                              [EXTRA_PATH_VARS_SUFFIX path1 [path2 ...]]
+#                              [CONFIG_TEMPLATE <file>]
+#                              [UPPERCASE_FILENAMES | LOWERCASE_FILENAMES]
+#                              [DEPENDENCIES <dependency1> "<dependency2> [...]" ...]
+#                              [PRIVATE_DEPENDENCIES <dependency1> "<dependency2> [...]" ...]
+#                              [INCLUDE_FILE <file>]
+#                              [COMPONENT <component>] # (default = "<Name>")
+#                              [NO_COMPATIBILITY_VARS]
+#                             )
+#
+# Depending on UPPERCASE_FILENAMES and LOWERCASE_FILENAMES, this
+# function generates 3 files:
+#
+#  - ``<Name>ConfigVersion.cmake`` or ``<name>-config-version.cmake``
+#  - ``<Name>Config.cmake`` or ``<name>-config.cmake``
+#  - ``<Name>Targets.cmake`` or ``<name>-targets.cmake``
+#
+# If neither ``UPPERCASE_FILENAMES`` nor ``LOWERCASE_FILENAMES`` is
+# set, a file ``<Name>ConfigVersion.cmake.in`` or
+# ``<name>-config-version.cmake.in`` is searched, and the convention
+# is chosed according to the file found. If no file was found, the
+# uppercase convention is used.
+#
+# The ``DEPENDENCIES`` argument can be used to set a list of dependencies
+# that will be searched using the :command:`find_dependency` command
+# from the :module:`CMakeFindDependencyMacro` module.
+# Dependencies can be followed by any of the possible :command:`find_dependency`
+# argument.
+# In this case, all the arguments must be specified within double quotes (e.g.
+# "<dependency> 1.0.0 EXACT", "<dependency> CONFIG").
+# The ``PRIVATE_DEPENDENCIES`` argument is similar to ``DEPENDENCIES``, but
+# these dependencies are included only when libraries are built ``STATIC``, i.e.
+# if ``BUILD_SHARED_LIBS`` is ``OFF`` or if the ``TYPE`` property for one or
+# more of the targets is ``STATIC_LIBRARY``.
+# When using a custom template file, the ``@PACKAGE_DEPENDENCIES@``
+# string is replaced with the code checking for the dependencies
+# specified by these two argument.
+#
+# Each file is generated twice, one for the build directory and one for
+# the installation directory.  The ``INSTALL_DESTINATION`` argument can be
+# passed to install the files in a location different from the default
+# one (``CMake`` on Windows, ``${CMAKE_INSTALL_LIBDIR}/cmake/${Name}``
+# on other platforms.  The ``EXPORT_DESTINATION`` argument can be passed to
+# generate the files in the build tree in a location different from the default
+# one (``CMAKE_BINARY_DIR``).  If this is a relative path, it is considered
+# relative to the ``CMAKE_BINARY_DIR`` directory.
+#
+# The ``<Name>ConfigVersion.cmake`` is generated using
+# ``write_basic_package_version_file``.  The ``VERSION``,
+# ``COMPATIBILITY``, ``NO_SET_AND_CHECK_MACRO``, and
+# ``NO_CHECK_REQUIRED_COMPONENTS_MACRO`` are passed to this function
+# and are used internally by :module:`CMakePackageConfigHelpers` module.
+#
+# ``VERSION`` shall be in the form ``<major>[.<minor>[.<patch>[.<tweak>]]]]``.
+# If no ``VERSION`` is given, the ``PROJECT_VERSION`` variable is used.
+# If this hasn’t been set, it errors out.  The ``VERSION`` argument is also used
+# to replace the ``@PACKAGE_VERSION@`` string in the configuration file.
+#
+# ``COMPATIBILITY`` shall be any of ``<AnyNewerVersion|SameMajorVersion|
+# ExactVersion>``.
+# The ``COMPATIBILITY`` mode ``AnyNewerVersion`` means that the installed
+# package version will be considered compatible if it is newer or exactly the
+# same as the requested version. This mode should be used for packages which are
+# fully backward compatible, also across major versions.
+# If ``SameMajorVersion`` is used instead, then the behaviour differs from
+# ``AnyNewerVersion`` in that the major version number must be the same as
+# requested, e.g. version 2.0 will not be considered compatible if 1.0 is
+# requested. This mode should be used for packages which guarantee backward
+# compatibility within the same major version. If ``ExactVersion`` is used, then
+# the package is only considered compatible if the requested version matches
+# exactly its own version number (not considering the tweak version). For
+# example, version 1.2.3 of a package is only considered compatible to requested
+# version 1.2.3. This mode is for packages without compatibility guarantees. If
+# your project has more elaborated version matching rules, you will need to
+# write your own custom ConfigVersion.cmake file instead of using this macro.
+#
+# By default ``install_basic_package_files`` also generates the two helper
+# macros ``set_and_check()`` and ``check_required_components()`` into the
+# ``<Name>Config.cmake`` file. ``set_and_check()`` should be used instead of the
+# normal set() command for setting directories and file locations. Additionally
+# to setting the variable it also checks that the referenced file or directory
+# actually exists and fails with a ``FATAL_ERROR`` otherwise. This makes sure
+# that the created ``<Name>Config.cmake`` file does not contain wrong
+# references. When using the ``NO_SET_AND_CHECK_MACRO, this macro is not
+# generated into the ``<Name>Config.cmake`` file.
+#
+# By default, ``install_basic_package_files`` append a call to
+# ``check_required_components(<Name>)`` in <Name>Config.cmake file if the
+# package supports components. This macro checks whether all requested,
+# non-optional components have been found, and if this is not the case, sets the
+# ``<Name>_FOUND`` variable to ``FALSE``, so that the package is considered to
+# be not found. It does that by testing the ``<Name>_<Component>_FOUND``
+# variables for all requested required components. When using the
+# ``NO_CHECK_REQUIRED_COMPONENTS_MACRO`` option, this macro is not generated
+# into the <Name>Config.cmake file.
+#
+# Finally, the files in the build and install directory are exactly the same.
+#
+# See the documentation of :module:`CMakePackageConfigHelpers` module for
+# further information and references therein.
+#
+#
+# The ``<Name>Config.cmake`` is generated using
+# ``configure_package_config_file``.  See the documentation for the
+# :module:`CMakePackageConfigHelpers` module for further information.
+# If the ``CONFIG_TEMPLATE`` argument is passed, the specified file
+# is used as template for generating the configuration file, otherwise
+# this module expects to find a ``<Name>Config.cmake.in`` or
+# ``<name>-config.cmake.in`` file either in the root directory of the
+# project or in current source directory.
+# If the file does not exist, a very basic file is created.
+#
+# A set of variables are checked and passed to
+# ``configure_package_config_file`` as ``PATH_VARS``. For each of the
+# ``SUFFIX`` considered, if one of the variables::
+#
+#     <VARS_PREFIX>_(BUILD|INSTALL)_<SUFFIX>
+#     (BUILD|INSTALL)_<VARS_PREFIX>_<SUFFIX>
+#
+# is defined, the ``<VARS_PREFIX>_<SUFFIX>`` variable will be defined
+# before configuring the package.  In order to use that variable in the
+# config file, you have to add a line::
+#
+#   set_and_check(<VARS_PREFIX>_<SUFFIX> \"@PACKAGE_<VARS_PREFIX>_<SUFFIX>@\")
+#
+# if the path must exist or just::
+#
+#   set(<VARS_PREFIX>_<SUFFIX> \"@PACKAGE_<VARS_PREFIX>_<SUFFIX>@\")
+#
+# if the path could be missing.
+#
+# These variable will have different values whether you are using the
+# package from the build tree or from the install directory.  Also these
+# files will contain only relative paths, meaning that you can move the
+# whole installation and the CMake files will still work.
+#
+# Default ``PATH_VARS`` suffixes are::
+#
+#   BINDIR          BIN_DIR
+#   SBINDIR         SBIN_DIR
+#   LIBEXECDIR      LIBEXEC_DIR
+#   SYSCONFDIR      SYSCONF_DIR
+#   SHAREDSTATEDIR  SHAREDSTATE_DIR
+#   LOCALSTATEDIR   LOCALSTATE_DIR
+#   LIBDIR          LIB_DIR
+#   INCLUDEDIR      INCLUDE_DIR
+#   OLDINCLUDEDIR   OLDINCLUDE_DIR
+#   DATAROOTDIR     DATAROOT_DIR
+#   DATADIR         DATA_DIR
+#   INFODIR         INFO_DIR
+#   LOCALEDIR       LOCALE_DIR
+#   MANDIR          MAN_DIR
+#   DOCDIR          DOC_DIR
+#
+# more suffixes can be added using the ``EXTRA_PATH_VARS_SUFFIX``
+# argument.
+#
+#
+# The ``<Name>Targets.cmake`` is generated using
+# :command:`export(TARGETS)` (if ``EXPORT`` or no options are used) or
+# :command:`export(TARGETS)` (if `EXPORT` is not used and one between
+# ``TARGETS``, ``TARGETS_PROPERTY``, or ``TARGETS_PROPERTIES`` is used) in the
+# build tree and :command:`install(EXPORT)` in the installation directory.
+# The targets are exported using the value for the ``NAMESPACE``
+# argument as namespace.
+# The export can be passed using the `EXPORT` argument.
+# The targets can be passed using the `TARGETS` argument or using one or more
+# global properties, that can be passed to the function using the
+# ``TARGETS_PROPERTY`` or ``TARGET_PROPERTIES`` arguments.
+#
+# If the ``NO_COMPATIBILITY_VARS`` argument is not set, the compatibility
+# variables ``<VARS_PREFIX>_LIBRARIES`` and ``<VARS_PREFIX>_INCLUDE_DIRS``
+# are set, trying to guess their correct values from the variables set or
+# from the arguments passed to this command. This argument is ignored if
+# the template file is not generated by this command.
+#
+# If the ``INCLUDE_FILE`` argument is passed, the content of the specified file
+# (which might be templated) is appended to the ``<Name>Config.cmake``.
+# This allows to inject custom code to this file, useful e.g. to set additional
+# variables which are loaded by downstream projects.
+#
+# If the ``COMPONENT`` argument is passed, it is forwarded to the
+# :command:`install` commands, otherwise <Name> is used.
+
+#=============================================================================
+# Copyright 2013 Istituto Italiano di Tecnologia (IIT)
+#   Authors: Daniele E. Domenichelli <daniele.domenichelli@iit.it>
+#
+# Distributed under the OSI-approved BSD License (the "License");
+# see accompanying file Copyright.txt for details.
+#
+# This software is distributed WITHOUT ANY WARRANTY; without even the
+# implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See the License for more information.
+#=============================================================================
+# (To distribute this file outside of CMake, substitute the full
+#  License text for the above reference.)
+
+
+if(COMMAND install_basic_package_files)
+  return()
+endif()
+
+
+include(GNUInstallDirs)
+include(CMakePackageConfigHelpers)
+include(CMakeParseArguments)
+
+
+function(INSTALL_BASIC_PACKAGE_FILES _Name)
+
+  # TODO check that _Name does not contain "-" characters
+
+  set(_options NO_SET_AND_CHECK_MACRO
+               NO_CHECK_REQUIRED_COMPONENTS_MACRO
+               UPPERCASE_FILENAMES
+               LOWERCASE_FILENAMES
+               NO_COMPATIBILITY_VARS)
+  set(_oneValueArgs VERSION
+                    COMPATIBILITY
+                    EXPORT
+                    FIRST_TARGET
+                    TARGETS_PROPERTY
+                    VARS_PREFIX
+                    EXPORT_DESTINATION
+                    INSTALL_DESTINATION
+                    DESTINATION
+                    NAMESPACE
+                    CONFIG_TEMPLATE
+                    INCLUDE_FILE
+                    COMPONENT)
+  set(_multiValueArgs EXTRA_PATH_VARS_SUFFIX
+                      TARGETS
+                      TARGETS_PROPERTIES
+                      DEPENDENCIES
+                      PRIVATE_DEPENDENCIES)
+  cmake_parse_arguments(_IBPF "${_options}" "${_oneValueArgs}" "${_multiValueArgs}" "${ARGN}")
+
+  if(NOT DEFINED _IBPF_VARS_PREFIX)
+    set(_IBPF_VARS_PREFIX ${_Name})
+  endif()
+
+  if(NOT DEFINED _IBPF_VERSION)
+    message(FATAL_ERROR "VERSION argument is required")
+  endif()
+
+  if(NOT DEFINED _IBPF_COMPATIBILITY)
+    message(FATAL_ERROR "COMPATIBILITY argument is required")
+  endif()
+
+  if(_IBPF_UPPERCASE_FILENAMES AND _IBPF_LOWERCASE_FILENAMES)
+    message(FATAL_ERROR "UPPERCASE_FILENAMES and LOWERCASE_FILENAMES arguments cannot be used together")
+  endif()
+
+  # Prepare install and export commands
+  set(_first_target ${_Name})
+  set(_targets ${_Name})
+  set(_install_cmd EXPORT ${_Name})
+  set(_export_cmd EXPORT ${_Name})
+
+  if(DEFINED _IBPF_FIRST_TARGET)
+    if(DEFINED _IBPF_TARGETS OR DEFINED _IBPF_TARGETS_PROPERTIES OR DEFINED _IBPF_TARGETS_PROPERTIES)
+      message(FATAL_ERROR "EXPORT cannot be used with TARGETS, TARGETS_PROPERTY or TARGETS_PROPERTIES")
+    endif()
+
+    set(_first_target ${_IBPF_FIRST_TARGET})
+    set(_targets ${_IBPF_FIRST_TARGET})
+  endif()
+
+  if(DEFINED _IBPF_EXPORT)
+    if(DEFINED _IBPF_TARGETS OR DEFINED _IBPF_TARGETS_PROPERTIES OR DEFINED _IBPF_TARGETS_PROPERTIES)
+      message(FATAL_ERROR "EXPORT cannot be used with TARGETS, TARGETS_PROPERTY or TARGETS_PROPERTIES")
+    endif()
+
+    set(_export_cmd EXPORT ${_IBPF_EXPORT})
+    set(_install_cmd EXPORT ${_IBPF_EXPORT})
+
+  elseif(DEFINED _IBPF_TARGETS)
+    if(DEFINED _IBPF_TARGETS_PROPERTY OR DEFINED _IBPF_TARGETS_PROPERTIES)
+      message(FATAL_ERROR "TARGETS cannot be used with TARGETS_PROPERTY or TARGETS_PROPERTIES")
+    endif()
+
+    set(_targets ${_IBPF_TARGETS})
+    set(_export_cmd TARGETS ${_IBPF_TARGETS})
+    list(GET _targets 0 _first_target)
+
+  elseif(DEFINED _IBPF_TARGETS_PROPERTY)
+    if(DEFINED _IBPF_TARGETS_PROPERTIES)
+      message(FATAL_ERROR "TARGETS_PROPERTIES cannot be used with TARGETS_PROPERTIES")
+    endif()
+
+    get_property(_targets GLOBAL PROPERTY ${_IBPF_TARGETS_PROPERTY})
+    set(_export_cmd TARGETS ${_targets})
+    list(GET _targets 0 _first_target)
+
+  elseif(DEFINED _IBPF_TARGETS_PROPERTIES)
+
+    unset(_targets)
+    foreach(_prop ${_IBPF_TARGETS_PROPERTIES})
+      get_property(_prop_val GLOBAL PROPERTY ${_prop})
+      list(APPEND _targets ${_prop_val})
+    endforeach()
+    set(_export_cmd TARGETS ${_targets})
+    list(GET _targets 0 _first_target)
+
+  endif()
+
+  # Path for installed cmake files
+  if(DEFINED _IBPF_DESTINATION)
+    message(DEPRECATION "DESTINATION is deprecated. Use INSTALL_DESTINATION instead")
+    if(NOT DEFINED _IBPF_INSTALL_DESTINATION)
+      set(_IBPF_INSTALL_DESTINATION ${_IBPF_DESTINATION})
+    endif()
+  endif()
+
+  if(NOT DEFINED _IBPF_INSTALL_DESTINATION)
+    if(WIN32 AND NOT CYGWIN)
+      set(_IBPF_INSTALL_DESTINATION CMake)
+    else()
+      set(_IBPF_INSTALL_DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/${_Name})
+    endif()
+  endif()
+
+  if(NOT DEFINED _IBPF_EXPORT_DESTINATION)
+    set(_IBPF_EXPORT_DESTINATION "${CMAKE_BINARY_DIR}")
+  elseif(NOT IS_ABSOLUTE _IBPF_EXPORT_DESTINATION)
+    set(_IBPF_EXPORT_DESTINATION "${CMAKE_BINARY_DIR}/${_IBPF_EXPORT_DESTINATION}")
+  endif()
+
+  if(NOT DEFINED _IBPF_NAMESPACE)
+    set(_IBPF_NAMESPACE "${_Name}::")
+  endif()
+
+  if(NOT DEFINED _IBPF_COMPONENT)
+    set(_IBPF_COMPONENT "${_Name}")
+  endif()
+
+  if(_IBPF_NO_SET_AND_CHECK_MACRO)
+    list(APPEND configure_package_config_file_extra_args NO_SET_AND_CHECK_MACRO)
+  endif()
+
+  if(_IBPF_NO_CHECK_REQUIRED_COMPONENTS_MACRO)
+    list(APPEND configure_package_config_file_extra_args NO_CHECK_REQUIRED_COMPONENTS_MACRO)
+  endif()
+
+
+
+  # Set input file for config, and ensure that _IBPF_UPPERCASE_FILENAMES
+  # and _IBPF_LOWERCASE_FILENAMES are set correctly
+  unset(_config_cmake_in)
+  set(_generate_file 0)
+  if(DEFINED _IBPF_CONFIG_TEMPLATE)
+    if(NOT EXISTS "${_IBPF_CONFIG_TEMPLATE}")
+      message(FATAL_ERROR "Config template file \"${_IBPF_CONFIG_TEMPLATE}\" not found")
+    endif()
+    set(_config_cmake_in "${_IBPF_CONFIG_TEMPLATE}")
+    if(NOT _IBPF_UPPERCASE_FILENAMES AND NOT _IBPF_LOWERCASE_FILENAMES)
+      if("${_IBPF_CONFIG_TEMPLATE}" MATCHES "${_Name}Config.cmake.in")
+        set(_IBPF_UPPERCASE_FILENAMES 1)
+      elseif("${_IBPF_CONFIG_TEMPLATE}" MATCHES "${_name}-config.cmake.in")
+        set(_IBPF_LOWERCASE_FILENAMES 1)
+      else()
+        set(_IBPF_UPPERCASE_FILENAMES 1)
+      endif()
+    endif()
+  else()
+    string(TOLOWER "${_Name}" _name)
+    if(EXISTS "${CMAKE_SOURCE_DIR}/${_Name}Config.cmake.in")
+      set(_config_cmake_in "${CMAKE_SOURCE_DIR}/${_Name}Config.cmake.in")
+      if(NOT _IBPF_UPPERCASE_FILENAMES AND NOT _IBPF_LOWERCASE_FILENAMES)
+        set(_IBPF_UPPERCASE_FILENAMES 1)
+      endif()
+    elseif(EXISTS "${CMAKE_SOURCE_DIR}/${_name}-config.cmake.in")
+      set(_config_cmake_in "${CMAKE_SOURCE_DIR}/${_name}-config.cmake.in")
+      if(NOT _IBPF_UPPERCASE_FILENAMES AND NOT _IBPF_LOWERCASE_FILENAMES)
+        set(_IBPF_LOWERCASE_FILENAMES 1)
+      endif()
+    elseif(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/${_Name}Config.cmake.in")
+      set(_config_cmake_in "${CMAKE_CURRENT_SOURCE_DIR}/${_Name}Config.cmake.in")
+      if(NOT _IBPF_UPPERCASE_FILENAMES AND NOT _IBPF_LOWERCASE_FILENAMES)
+        set(_IBPF_UPPERCASE_FILENAMES 1)
+      endif()
+    elseif(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/${_name}-config.cmake.in")
+      set(_config_cmake_in "${CMAKE_CURRENT_SOURCE_DIR}/${_name}-config.cmake.in")
+      if(NOT _IBPF_UPPERCASE_FILENAMES AND NOT _IBPF_LOWERCASE_FILENAMES)
+        set(_IBPF_LOWERCASE_FILENAMES 1)
+      endif()
+    else()
+      set(_generate_file 1)
+      if(_IBPF_LOWERCASE_FILENAMES)
+        set(_config_cmake_in "${CMAKE_CURRENT_BINARY_DIR}/${_name}-config.cmake")
+      else()
+        set(_config_cmake_in "${CMAKE_CURRENT_BINARY_DIR}/${_Name}Config.cmake.in")
+        set(_IBPF_UPPERCASE_FILENAMES 1)
+      endif()
+    endif()
+  endif()
+
+  # Set input file containing user variables
+  if(DEFINED _IBPF_INCLUDE_FILE)
+    if(NOT IS_ABSOLUTE "${_IBPF_INCLUDE_FILE}")
+      if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/${_IBPF_INCLUDE_FILE}")
+        set(_IBPF_INCLUDE_FILE "${CMAKE_CURRENT_SOURCE_DIR}/${_IBPF_INCLUDE_FILE}")
+      endif()
+    endif()
+    if(NOT EXISTS "${_IBPF_INCLUDE_FILE}")
+        message(FATAL_ERROR "File \"${_IBPF_INCLUDE_FILE}\" not found")
+    endif()
+    file(READ ${_IBPF_INCLUDE_FILE} _includedfile_user_content_in)
+    string(CONFIGURE ${_includedfile_user_content_in} _includedfile_user_content)
+    set(INCLUDED_FILE_CONTENT
+"#### Expanded from INCLUDE_FILE by install_basic_package_files() ####")
+    set(INCLUDED_FILE_CONTENT "${INCLUDED_FILE_CONTENT}\n\n${_includedfile_user_content}")
+    set(INCLUDED_FILE_CONTENT
+"${INCLUDED_FILE_CONTENT}
+#####################################################################")
+  endif()
+
+  # Select output file names
+  if(_IBPF_UPPERCASE_FILENAMES)
+    set(_config_filename ${_Name}Config.cmake)
+    set(_version_filename ${_Name}ConfigVersion.cmake)
+    set(_targets_filename ${_Name}Targets.cmake)
+  elseif(_IBPF_LOWERCASE_FILENAMES)
+    set(_config_filename ${_name}-config.cmake)
+    set(_version_filename ${_name}-config-version.cmake)
+    set(_targets_filename ${_name}-targets.cmake)
+  endif()
+
+
+  # If the template config file does not exist, write a basic one
+  if(_generate_file)
+    # Generate the compatibility code
+    unset(_compatibility_vars)
+    if(NOT _IBPF_NO_COMPATIBILITY_VARS)
+      unset(_get_include_dir_code)
+      unset(_set_include_dir_code)
+      unset(_target_list)
+      foreach(_target ${_targets})
+        list(APPEND _target_list ${_IBPF_NAMESPACE}${_target})
+      endforeach()
+      if(DEFINED ${_IBPF_VARS_PREFIX}_BUILD_INCLUDEDIR OR
+         DEFINED BUILD_${_IBPF_VARS_PREFIX}_INCLUDEDIR OR
+         DEFINED ${_IBPF_VARS_PREFIX}_INSTALL_INCLUDEDIR OR
+         DEFINED INSTALL_${_IBPF_VARS_PREFIX}_INCLUDEDIR)
+        set(_get_include_dir "set(${_IBPF_VARS_PREFIX}_INCLUDEDIR \"\@PACKAGE_${_IBPF_VARS_PREFIX}_INCLUDEDIR\@\")\n")
+        set(_set_include_dir "set(${_Name}_INCLUDE_DIRS \"\${${_IBPF_VARS_PREFIX}_INCLUDEDIR}\")")
+      elseif(DEFINED ${_IBPF_VARS_PREFIX}_BUILD_INCLUDE_DIR OR
+             DEFINED BUILD_${_IBPF_VARS_PREFIX}_INCLUDE_DIR OR
+             DEFINED ${_IBPF_VARS_PREFIX}_INSTALL_INCLUDE_DIR OR
+             DEFINED INSTALL_${_IBPF_VARS_PREFIX}_INCLUDE_DIR)
+        set(_get_include_dir "set(${_IBPF_VARS_PREFIX}_INCLUDE_DIR \"\@PACKAGE_${_IBPF_VARS_PREFIX}_INCLUDE_DIR\@\")\n")
+        set(_set_include_dir "set(${_Name}_INCLUDE_DIRS \"\${${_IBPF_VARS_PREFIX}_INCLUDE_DIR}\")")
+      else()
+        unset(_include_dir_list)
+        foreach(_target ${_targets})
+          set(_get_include_dir "${_get_include_dir}get_property(${_IBPF_VARS_PREFIX}_${_target}_INCLUDE_DIR TARGET ${_IBPF_NAMESPACE}${_target} PROPERTY INTERFACE_INCLUDE_DIRECTORIES)\n")
+          list(APPEND _include_dir_list "\"\${${_IBPF_VARS_PREFIX}_${_target}_INCLUDE_DIR}\"")
+        endforeach()
+        string(REPLACE ";" " " _include_dir_list "${_include_dir_list}")
+        string(REPLACE ";" " " _target_list "${_target_list}")
+        set(_set_include_dir "set(${_Name}_INCLUDE_DIRS ${_include_dir_list})\nlist(REMOVE_DUPLICATES ${_Name}_INCLUDE_DIRS)")
+      endif()
+      set(_compatibility_vars "# Compatibility\n${_get_include_dir}\nset(${_Name}_LIBRARIES ${_target_list})\n${_set_include_dir}")
+    endif()
+
+    # Write the file
+    file(WRITE "${_config_cmake_in}"
+"set(${_IBPF_VARS_PREFIX}_VERSION \@PACKAGE_VERSION\@)
+
+\@PACKAGE_INIT\@
+
+\@PACKAGE_DEPENDENCIES\@
+
+if(NOT TARGET ${_IBPF_NAMESPACE}${_first_target})
+  include(\"\${CMAKE_CURRENT_LIST_DIR}/${_targets_filename}\")
+endif()
+
+${_compatibility_vars}
+
+\@INCLUDED_FILE_CONTENT\@
+")
+  endif()
+
+  # Make relative paths absolute (needed later on) and append the
+  # defined variables to _(build|install)_path_vars_suffix
+  foreach(p BINDIR          BIN_DIR
+            SBINDIR         SBIN_DIR
+            LIBEXECDIR      LIBEXEC_DIR
+            SYSCONFDIR      SYSCONF_DIR
+            SHAREDSTATEDIR  SHAREDSTATE_DIR
+            LOCALSTATEDIR   LOCALSTATE_DIR
+            LIBDIR          LIB_DIR
+            INCLUDEDIR      INCLUDE_DIR
+            OLDINCLUDEDIR   OLDINCLUDE_DIR
+            DATAROOTDIR     DATAROOT_DIR
+            DATADIR         DATA_DIR
+            INFODIR         INFO_DIR
+            LOCALEDIR       LOCALE_DIR
+            MANDIR          MAN_DIR
+            DOCDIR          DOC_DIR
+            ${_IBPF_EXTRA_PATH_VARS_SUFFIX})
+    if(DEFINED ${_IBPF_VARS_PREFIX}_BUILD_${p})
+      list(APPEND _build_path_vars_suffix ${p})
+      list(APPEND _build_path_vars "${_IBPF_VARS_PREFIX}_${p}")
+    endif()
+    if(DEFINED BUILD_${_IBPF_VARS_PREFIX}_${p})
+      list(APPEND _build_path_vars_suffix ${p})
+      list(APPEND _build_path_vars "${_IBPF_VARS_PREFIX}_${p}")
+    endif()
+    if(DEFINED ${_IBPF_VARS_PREFIX}_INSTALL_${p})
+      list(APPEND _install_path_vars_suffix ${p})
+      list(APPEND _install_path_vars "${_IBPF_VARS_PREFIX}_${p}")
+    endif()
+    if(DEFINED INSTALL_${_IBPF_VARS_PREFIX}_${p})
+      list(APPEND _install_path_vars_suffix ${p})
+      list(APPEND _install_path_vars "${_IBPF_VARS_PREFIX}_${p}")
+    endif()
+  endforeach()
+
+
+  # <Name>ConfigVersion.cmake file (same for build tree and intall)
+  write_basic_package_version_file("${_IBPF_EXPORT_DESTINATION}/${_version_filename}"
+                                   VERSION ${_IBPF_VERSION}
+                                   COMPATIBILITY ${_IBPF_COMPATIBILITY})
+  install(FILES "${_IBPF_EXPORT_DESTINATION}/${_version_filename}"
+          DESTINATION ${_IBPF_INSTALL_DESTINATION}
+          COMPONENT ${_IBPF_COMPONENT})
+
+
+  # Prepare PACKAGE_DEPENDENCIES variable
+  set(_need_private_deps 0)
+  if(NOT BUILD_SHARED_LIBS)
+    set(_need_private_deps 1)
+  else()
+    foreach(_target ${_targets})
+      get_property(_type TARGET ${_target} PROPERTY TYPE)
+      if("${_type}" STREQUAL "STATIC_LIBRARY")
+        set(_need_private_deps 1)
+        break()
+      endif()
+    endforeach()
+  endif()
+
+  unset(PACKAGE_DEPENDENCIES)
+  if(DEFINED _IBPF_DEPENDENCIES)
+    set(PACKAGE_DEPENDENCIES "#### Expanded from @PACKAGE_DEPENDENCIES@ by install_basic_package_files() ####\n\ninclude(CMakeFindDependencyMacro)\n")
+
+    # FIXME When CMake 3.9 or greater is required, remove this madness and just
+    #       use find_dependency
+    if (CMAKE_VERSION VERSION_LESS 3.9)
+      string(APPEND PACKAGE_DEPENDENCIES "
+set(_${_Name}_FIND_PARTS_REQUIRED)
+if (${_Name}_FIND_REQUIRED)
+  set(_${_Name}_FIND_PARTS_REQUIRED REQUIRED)
+endif()
+set(_${_Name}_FIND_PARTS_QUIET)
+if (${_Name}_FIND_QUIETLY)
+  set(_${_Name}_FIND_PARTS_QUIET QUIET)
+endif()
+")
+
+      foreach(_dep ${_IBPF_DEPENDENCIES})
+        if("${_dep}" MATCHES ".+ .+")
+            string(REPLACE " " ";" _dep_list "${_dep}")
+            list(INSERT _dep_list 1 \${_${_Name}_FIND_PARTS_QUIET} \${_${_Name}_FIND_PARTS_REQUIRED})
+            string(REPLACE ";" " " _depx "${_dep_list}")
+            string(APPEND PACKAGE_DEPENDENCIES "find_package(${_depx})\n")
+        else()
+          string(APPEND PACKAGE_DEPENDENCIES "find_dependency(${_dep})\n")
+        endif()
+      endforeach()
+      if(_need_private_deps)
+        foreach(_dep ${_IBPF_PRIVATE_DEPENDENCIES})
+          if("${_dep}" MATCHES ".+ .+")
+            string(REPLACE " " ";" _dep_list "${_dep}")
+            list(INSERT _dep_list 1 \${_${_Name}_FIND_PARTS_QUIET} \${_${_Name}_FIND_PARTS_REQUIRED})
+            string(REPLACE ";" "\n       " _depx "${_dep_list}")
+            string(APPEND PACKAGE_DEPENDENCIES "find_package(${_depx})\n")
+          else()
+            string(APPEND PACKAGE_DEPENDENCIES "find_dependency(${_dep})\n")
+          endif()
+          endforeach()
+      endif()
+
+    else()
+
+      foreach(_dep ${_IBPF_DEPENDENCIES})
+        string(APPEND PACKAGE_DEPENDENCIES "find_dependency(${_dep})\n")
+      endforeach()
+      if(_need_private_deps)
+        foreach(_dep ${_IBPF_PRIVATE_DEPENDENCIES})
+          string(APPEND PACKAGE_DEPENDENCIES "find_dependency(${_dep})\n")
+        endforeach()
+      endif()
+
+    endif()
+
+    set(PACKAGE_DEPENDENCIES "${PACKAGE_DEPENDENCIES}\n###############################################################################\n")
+  endif()
+
+  # Prepare PACKAGE_VERSION variable
+  set(PACKAGE_VERSION ${_IBPF_VERSION})
+
+  # <Name>Config.cmake (build tree)
+  foreach(p ${_build_path_vars_suffix})
+    if(DEFINED ${_IBPF_VARS_PREFIX}_BUILD_${p})
+      set(${_IBPF_VARS_PREFIX}_${p} "${${_IBPF_VARS_PREFIX}_BUILD_${p}}")
+    elseif(DEFINED BUILD_${_IBPF_VARS_PREFIX}_${p})
+      set(${_IBPF_VARS_PREFIX}_${p} "${BUILD_${_IBPF_VARS_PREFIX}_${p}}")
+    endif()
+  endforeach()
+  configure_package_config_file("${_config_cmake_in}"
+                                "${_IBPF_EXPORT_DESTINATION}/${_config_filename}"
+                                INSTALL_DESTINATION ${_IBPF_EXPORT_DESTINATION}
+                                PATH_VARS ${_build_path_vars}
+                                ${configure_package_config_file_extra_args}
+                                INSTALL_PREFIX ${CMAKE_BINARY_DIR})
+
+  # <Name>Config.cmake (installed)
+  foreach(p ${_install_path_vars_suffix})
+    if(DEFINED ${_IBPF_VARS_PREFIX}_INSTALL_${p})
+      set(${_IBPF_VARS_PREFIX}_${p} "${${_IBPF_VARS_PREFIX}_INSTALL_${p}}")
+    elseif(DEFINED INSTALL_${_IBPF_VARS_PREFIX}_${p})
+      set(${_IBPF_VARS_PREFIX}_${p} "${INSTALL_${_IBPF_VARS_PREFIX}_${p}}")
+    endif()
+  endforeach()
+  configure_package_config_file("${_config_cmake_in}"
+                                "${CMAKE_CURRENT_BINARY_DIR}/${_config_filename}.install"
+                                INSTALL_DESTINATION ${_IBPF_INSTALL_DESTINATION}
+                                PATH_VARS ${_install_path_vars}
+                                ${configure_package_config_file_extra_args})
+  install(FILES "${CMAKE_CURRENT_BINARY_DIR}/${_config_filename}.install"
+          DESTINATION ${_IBPF_INSTALL_DESTINATION}
+          RENAME ${_config_filename}
+          COMPONENT ${_IBPF_COMPONENT})
+
+
+  # <Name>Targets.cmake (build tree)
+  export(${_export_cmd}
+         NAMESPACE ${_IBPF_NAMESPACE}
+         FILE "${_IBPF_EXPORT_DESTINATION}/${_targets_filename}")
+
+  # <Name>Targets.cmake (installed)
+  install(${_install_cmd}
+          NAMESPACE ${_IBPF_NAMESPACE}
+          DESTINATION ${_IBPF_INSTALL_DESTINATION}
+          FILE "${_targets_filename}"
+          COMPONENT ${_IBPF_COMPONENT})
+endfunction()


### PR DESCRIPTION
This PR implements the `cmake` build-system for scs. The build system is just a different way to build/install scs. The project can be still built using the `makefile`.


The `cmake` build-system exports two CMake targets called `scs::scsdir` and`scs::scsindir` which can be imported with the `find_package` CMake command by calling `target_link_libraries` as in the following example:
```cmake
cmake_minimum_required(VERSION 3.0)
project(myproject)
find_package(scs REQUIRED)
add_executable(example example.cpp)

# To use the direct method
target_link_libraries(example scs::scsdir)
# To use the indirect method
target_link_libraries(example scs::scsindir)
```

This PR closes #151 

cc @traversaro  @h-vetinari @bodono 