### PR TITLE
Add USE_LAPACK as CMake option, with default true

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -121,11 +121,14 @@ message(STATUS "Printing is NOT ${NO_PRINTING}")
 option(NO_READ_WRITE "Disables all read/write functionality" OFF)
 message(STATUS "Read/write functionality is NOT ${NO_READ_WRITE}")
 
+option(USE_LAPACK "Whether to use BLAS/LAPACK" ON)
+message(STATUS "BLAS/LAPACK usage is ${USE_LAPACK}")
+
 # Enable OpenMP support
 option(USE_OPENMP "Compile with OpenMP support" OFF)
 message(STATUS "OpenMP parallelization is ${USE_OPENMP}")
 
-set(COMPILER_OPTS "-DUSE_LAPACK -DCTRLC")
+set(COMPILER_OPTS "-DCTRLC")
 
 # Primitive types
 if(SFLOAT)
@@ -148,6 +151,10 @@ endif()
 
 if(NO_READ_WRITE)
   set(COMPILER_OPTS "-DNO_READ_WRITE=1 ${COMPILER_OPTS}")
+endif()
+
+if (USE_LAPACK)
+  set(COMPILER_OPTS "-DUSE_LAPACK ${COMPILER_OPTS}")
 endif()
 
 if(USE_OPENMP)


### PR DESCRIPTION
The `scs` Makefile recognizes the [compile flag `USE_LAPACK`](https://www.cvxgrp.org/scs/api/compile_flags.html), which controls whether LAPACK is linked in.  But when `scs` is used through CMake (with `add_subdirectory("scs")`), it unconditionally uses LAPACK; there is no way to set `USE_LAPACK=0`.

This MR adds `USE_LAPACK` as a CMake variable, alongside other CMake variables like like `DLONG` and `USE_OPENMP`.  This should allow CMake-based projects to control the `USE_LAPACK` compile option.  The default value is true, of course, for backward compatibility.