### PR TITLE
When USE_LAPACK is false, do not link against LAPACK

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -129,6 +129,7 @@ option(USE_OPENMP "Compile with OpenMP support" OFF)
 message(STATUS "OpenMP parallelization is ${USE_OPENMP}")
 
 set(COMPILER_OPTS "-DCTRLC")
+set(LAPACK_LINK_LIBRARIES "")
 
 # Primitive types
 if(SFLOAT)
@@ -155,6 +156,7 @@ endif()
 
 if (USE_LAPACK)
   set(COMPILER_OPTS "-DUSE_LAPACK ${COMPILER_OPTS}")
+  list(APPEND LAPACK_LINK_LIBRARIES "blas" "lapack")
 endif()
 
 if(USE_OPENMP)
@@ -242,8 +244,8 @@ target_include_directories(
 # Compiled with blas and lapack, can solve LPs, SOCPs, SDPs, ECPs, and PCPs
 target_compile_definitions(${${PROJECT_NAME}_DIRECT} PRIVATE ${COMPILER_OPTS})
 
-# The library depends on math (m) blas and lapack
-target_link_libraries(${${PROJECT_NAME}_DIRECT} PRIVATE m blas lapack)
+# The library depends on math (m) and (optionally) blas and lapack
+target_link_libraries(${${PROJECT_NAME}_DIRECT} PRIVATE m ${LAPACK_LINK_LIBRARIES})
 
 # Set some properties
 set_target_properties(
@@ -290,8 +292,8 @@ target_include_directories(
 target_compile_definitions(${${PROJECT_NAME}_INDIRECT} PRIVATE ${COMPILER_OPTS}
                                                                -DINDIRECT)
 
-# The library depends on math (m) blas and lapack
-target_link_libraries(${${PROJECT_NAME}_INDIRECT} PUBLIC m blas lapack)
+# The library depends on math (m) and (optionally) blas and lapack
+target_link_libraries(${${PROJECT_NAME}_INDIRECT} PUBLIC m ${LAPACK_LINK_LIBRARIES})
 
 # Set some properties
 set_target_properties(


### PR DESCRIPTION
In a recent pull request (https://github.com/cvxgrp/scs/pull/257), we added `USE_LAPACK` as a CMake-level variable controlling whether`USE_LAPACK` is defined during C compilation.

Unfortunately, that pull request failed to update the link-time dependencies of the `libscsdir` and `libscsindir` targets.  This PR fixes the `target_link_libraries()` declarations to link against `blas` and `lapack` if and only if `USE_LAPACK` is true.