### PR TITLE
add complex psd cone

### DIFF
--- a/cmake/scs_types.h.in
+++ b/cmake/scs_types.h.in
@@ -15,8 +15,11 @@
 extern "C" {
 #endif
 
+#include <complex.h>
+
 typedef @SCS_INT_TYPE@    scs_int;
 typedef @SCS_FLOAT_TYPE@  scs_float;
+typedef @SCS_FLOAT_TYPE@ _Complex scs_complex_float;
 
 #ifdef __cplusplus
 }

--- a/docs/src/api/cones.rst
+++ b/docs/src/api/cones.rst
@@ -33,6 +33,10 @@ The cone :math:`\mathcal{K}` can be any Cartesian product of the following primi
      - :math:`\{ s \in \mathbf{R}^{k(k+1)/2} \mid \text{mat}(s) \succeq 0 \}` (See :ref:`note <sdcone>`)
      - :code:`s` array of PSD cone lengths with :code:`ssize` elements, each :math:`s_i = k_i` in description.
      - :math:`\displaystyle \sum_{i=1}^{\text{ssize}} \frac{s_i(s_i+1)}{2}`
+   * - Complex positive semidefinite cone
+     - :math:`\{ s \in \mathbf{R}^{k^2} \mid \text{mat}(s) \succeq 0 \}` (See :ref:`note <sdcone>`)
+     - :code:`cs` array of PSD cone lengths with :code:`cssize` elements, each :math:`cs_i = k_i` in description.
+     - :math:`\displaystyle \sum_{i=1}^{\text{cssize}} cs_i^2`
    * - Exponential cone
      - :math:`\{   (x,y,z) \in \mathbf{R}^3 \mid y e^{x/y} \leq z, y>0  \}`
      - :code:`ep` number of cone triples.
@@ -49,10 +53,6 @@ The cone :math:`\mathcal{K}` can be any Cartesian product of the following primi
      - :math:`\{ (u,v,w)\in \mathbf{R}^3 \mid \left(\frac{u}{p}\right)^p \left(\frac{v}{1-p}\right)^{1-p} \geq |w|\}`
      - :code:`p` array :math:`p\in[-1,1]` powers with :code:`psize` elements, negative entries correspond to dual power cone (sign is flipped).
      - :math:`3 \times`:code:`psize` (total for primal and dual power cone)
-   * - Complex positive semidefinite cone
-     - :math:`\{ s \in \mathbf{R}^{k^2} \mid \text{mat}(s) \succeq 0 \}` (See :ref:`note <sdcone>`)
-     - :code:`cs` array of PSD cone lengths with :code:`cssize` elements, each :math:`cs_i = k_i` in description.
-     - :math:`\displaystyle \sum_{i=1}^{\text{cssize}} cs_i^2`
 
 
 **Note**:

--- a/docs/src/api/cones.rst
+++ b/docs/src/api/cones.rst
@@ -88,9 +88,9 @@ and for short we use :math:`S \succeq 0` to denote membership. SCS
 vectorizes these cones in a special way which we detail here.
 
 SCS assumes that the input data corresponding to positive semidefinite cones have been vectorized by scaling the off-diagonal entries by
-:math:`\sqrt{2}` and stacking the real parameters of the upper triangular row-wise. For a :math:`k \times k`
-real matrix variable (or data matrix) this operation would create a vector of length
-:math:`k(k+1)/2`, whereas for a :math:`k \times k` complex matrix its creates a vector of length :math:`k^2`. Scaling by :math:`\sqrt{2}` is required to preserve the inner-product.
+:math:`\sqrt{2}` and stacking the real parameters of the lower triangle column-wise. For a :math:`k \times k`
+real matrix variable (or data matrix) this operation creates a vector of length
+:math:`k(k+1)/2`, whereas for a :math:`k \times k` complex matrix it creates a vector of length :math:`k^2`. Scaling by :math:`\sqrt{2}` is required to preserve the inner-product.
 
 **This must be done for the rows of both** :math:`A` **and** :math:`b` **that correspond to semidefinite cones and must be done independently for each semidefinite cone.**
 
@@ -105,20 +105,20 @@ where the :math:`\text{vec}` operation takes the :math:`k \times k` matrix
           S_{k1} & S_{k2} & \ldots & S_{kk}  \\
         \end{bmatrix}
 
-and produces a vector consisting of the upper triangular real parameters elements scaled and re-arranged. In the real case, the result is
+and produces a vector consisting of the lower triangular real parameters scaled and re-arranged. In the real case, the result is
 
 .. math::
-  \text{vec}(S) = (S_{11}, \sqrt{2} S_{12}, \ldots, \sqrt{2} S_{1k}, S_{22}, \sqrt{2}S_{23}, \dots, S_{k-1,k-1}, \sqrt{2}S_{k-1,k}, S_{kk}) \in \mathbf{R}^{k(k+1)/2},
+  \text{vec}(S) = (S_{11}, \sqrt{2} S_{21}, \ldots, \sqrt{2} S_{k1}, S_{22}, \sqrt{2}S_{32}, \dots, S_{k-1,k-1}, \sqrt{2}S_{k,k-1}, S_{kk}) \in \mathbf{R}^{k(k+1)/2},
 
 whereas in the complex case the result is
 
 .. math::
-  \text{vec}(S) = (S_{11}, \sqrt{2} \Re(S_{12}), \sqrt{2} \Im(S_{12}), \ldots, \sqrt{2} \Re(S_{1k}), \sqrt{2} \Im(S_{1k}), S_{22}, \\\sqrt{2}\Re(S_{23}), \sqrt{2}\Im(S_{23}), \dots, S_{k-1,k-1}, \sqrt{2}\Re(S_{k-1,k}), \sqrt{2}\Im(S_{k-1,k}), S_{kk}) \in \mathbf{R}^{k^2}.
+  \text{vec}(S) = (S_{11}, \sqrt{2} \Re(S_{21}), \sqrt{2} \Im(S_{21}), \ldots, \sqrt{2} \Re(S_{k1}), \sqrt{2} \Im(S_{k1}), S_{22}, \\\sqrt{2}\Re(S_{32}), \sqrt{2}\Im(S_{32}), \dots, S_{k-1,k-1}, \sqrt{2}\Re(S_{k,k-1}), \sqrt{2}\Im(S_{k,k-1}), S_{kk}) \in \mathbf{R}^{k^2}.
 
 To recover the matrix solution this operation must be inverted on the components
 of the vectors returned by SCS corresponding to each semidefinite cone. That is, the
-off-diagonal entries must be scaled by :math:`1/\sqrt{2}` and the lower triangular
-entries are filled in by copying the values of upper triangular entries.
+off-diagonal entries must be scaled by :math:`1/\sqrt{2}` and the upper triangular
+entries are filled in by copying the values of lower triangular entries.
 Explicitly, in the real case the inverse operation takes vector :math:`s \in
 \mathbf{R}^{k(k+1)/2}` and produces the matrix
 
@@ -136,10 +136,10 @@ whereas in the complex case the inverse operation takes vector :math:`s \in
 
 .. math::
   \text{mat}(s) =  \begin{bmatrix}
-                    s_{1} & (s_{2} + i s_3) / \sqrt{2} & \ldots & (s_{2k-2}+is_{2k-1}) / \sqrt{2}  \\
-                    (s_{2} - i s_3) / \sqrt{2} / \sqrt{2} & s_{2k} & \ldots & (s_{4k-5}+is_{4k-4}) / \sqrt{2} \\
+                    s_{1} & (s_{2} - i s_3) / \sqrt{2} & \ldots & (s_{2k-2} - is_{2k-1}) / \sqrt{2}  \\
+                    (s_{2} + i s_3) / \sqrt{2} & s_{2k} & \ldots & (s_{4k-5} - is_{4k-4}) / \sqrt{2} \\
                     \vdots & \vdots & \ddots & \vdots  \\
-                    (s_{2k-2}-is_{2k-1}) / \sqrt{2} & (s_{4k-5}-is_{4k-4}) / \sqrt{2} & \ldots & s_{k^2}  \\
+                    (s_{2k-2} + is_{2k-1}) / \sqrt{2} & (s_{4k-5} + is_{4k-4}) / \sqrt{2} & \ldots & s_{k^2}  \\
                     \end{bmatrix}
   \in \mathbf{C}^{k \times k},
 

--- a/include/cones.h
+++ b/include/cones.h
@@ -28,8 +28,10 @@ struct SCS_CONE_WORK {
   scs_float box_t_warm_start;
 #ifdef USE_LAPACK
   /* workspace for eigenvector decompositions: */
-  scs_float *Xs, *Z, *e, *work;
-  blas_int lwork;
+  scs_float *Xs, *Z, *e, *work, *rwork;
+  scs_complex_float *cXs, *cZ, *cwork;
+  blas_int *isuppz, *iwork;
+  blas_int lwork, lcwork, lrwork, liwork;
 #endif
 };
 

--- a/include/scs.h
+++ b/include/scs.h
@@ -130,6 +130,10 @@ typedef struct {
   scs_int *s;
   /** Length of semidefinite constraints array `s`. */
   scs_int ssize;
+  /** Array of complex semidefinite cone constraints, `len(cs) = cssize`. */
+  scs_int *cs;
+  /** Length of complex semidefinite constraints array `cs`. */
+  scs_int cssize;
   /** Number of primal exponential cone triples. */
   scs_int ep;
   /** Number of dual exponential cone triples. */

--- a/include/scs.h
+++ b/include/scs.h
@@ -130,10 +130,6 @@ typedef struct {
   scs_int *s;
   /** Length of semidefinite constraints array `s`. */
   scs_int ssize;
-  /** Array of complex semidefinite cone constraints, `len(cs) = cssize`. */
-  scs_int *cs;
-  /** Length of complex semidefinite constraints array `cs`. */
-  scs_int cssize;
   /** Number of primal exponential cone triples. */
   scs_int ep;
   /** Number of dual exponential cone triples. */
@@ -143,6 +139,10 @@ typedef struct {
   scs_float *p;
   /** Number of (primal and dual) power cone triples. */
   scs_int psize;
+  /** Array of complex semidefinite cone constraints, `len(cs) = cssize`. */
+  scs_int *cs;
+  /** Length of complex semidefinite constraints array `cs`. */
+  scs_int cssize;
 } ScsCone;
 
 /** Contains primal-dual solution arrays or a certificate of infeasibility.

--- a/include/scs.h
+++ b/include/scs.h
@@ -130,6 +130,10 @@ typedef struct {
   scs_int *s;
   /** Length of semidefinite constraints array `s`. */
   scs_int ssize;
+  /** Array of complex semidefinite cone constraints, `len(cs) = cssize`. */
+  scs_int *cs;
+  /** Length of complex semidefinite constraints array `cs`. */
+  scs_int cssize;
   /** Number of primal exponential cone triples. */
   scs_int ep;
   /** Number of dual exponential cone triples. */
@@ -139,10 +143,6 @@ typedef struct {
   scs_float *p;
   /** Number of (primal and dual) power cone triples. */
   scs_int psize;
-  /** Array of complex semidefinite cone constraints, `len(cs) = cssize`. */
-  scs_int *cs;
-  /** Length of complex semidefinite constraints array `cs`. */
-  scs_int cssize;
 } ScsCone;
 
 /** Contains primal-dual solution arrays or a certificate of infeasibility.

--- a/include/scs_blas.h
+++ b/include/scs_blas.h
@@ -18,9 +18,11 @@ extern "C" {
 #ifndef SFLOAT
 #define BLAS(x) d##x
 #define BLASI(x) id##x
+#define BLASC(x) z##x
 #else
 #define BLAS(x) s##x
 #define BLASI(x) is##x
+#define BLASC(x) c##x
 #endif
 #else
 /* this extra indirection is needed for BLASSUFFIX to work correctly as a
@@ -31,9 +33,11 @@ extern "C" {
 #ifndef SFLOAT
 #define BLAS(x) stitch__(d, x, BLASSUFFIX)
 #define BLASI(x) stitch__(id, x, BLASSUFFIX)
+#define BLASC(x) stitch__(z, x, BLASSUFFIX)
 #else
 #define BLAS(x) stitch__(s, x, BLASSUFFIX)
 #define BLASI(x) stitch__(is, x, BLASSUFFIX)
+#define BLASC(x) stitch__(c, x, BLASSUFFIX)
 #endif
 #endif
 

--- a/include/scs_types.h
+++ b/include/scs_types.h
@@ -11,6 +11,8 @@
 extern "C" {
 #endif
 
+#include <complex.h>
+
 #ifdef DLONG
 /*#ifdef _WIN64
 #include <stdint.h>
@@ -26,8 +28,10 @@ typedef int scs_int;
 
 #ifndef SFLOAT
 typedef double scs_float;
+typedef double complex scs_complex_float;
 #else
 typedef float scs_float;
+typedef float complex scs_complex_float;
 #endif
 
 #ifdef __cplusplus

--- a/include/scs_types.h
+++ b/include/scs_types.h
@@ -28,10 +28,10 @@ typedef int scs_int;
 
 #ifndef SFLOAT
 typedef double scs_float;
-typedef double complex scs_complex_float;
+typedef double _Complex scs_complex_float;
 #else
 typedef float scs_float;
-typedef float complex scs_complex_float;
+typedef float _Complex scs_complex_float;
 #endif
 
 #ifdef __cplusplus

--- a/src/cones.c
+++ b/src/cones.c
@@ -173,6 +173,11 @@ void set_cone_boundaries(const ScsCone *k, ScsConeWork *c) {
     b[count + i] = s_cone_sz;
   }
   count += k->ssize; /* size here not ssize * (ssize + 1) / 2 */
+  for (i = 0; i < k->cssize; ++i) {
+    cs_cone_sz = get_csd_cone_size(k->cs[i]);
+    b[count + i] = cs_cone_sz;
+  }
+  count += k->cssize;
   /* exp cones */
   for (i = 0; i < k->ep + k->ed; ++i) {
     b[count + i] = 3;
@@ -183,11 +188,6 @@ void set_cone_boundaries(const ScsCone *k, ScsConeWork *c) {
     b[count + i] = 3;
   }
   count += k->psize;
-  for (i = 0; i < k->cssize; ++i) { /*adding the complex psd cone here for backwards compatibility */
-    cs_cone_sz = get_csd_cone_size(k->cs[i]);
-    b[count + i] = cs_cone_sz;
-  }
-  count += k->cssize;
   /* other cones */
   c->cone_boundaries = b;
   c->cone_boundaries_len = cone_boundaries_len;

--- a/src/cones.c
+++ b/src/cones.c
@@ -589,7 +589,7 @@ static scs_int set_up_csd_cone_work_space(ScsConeWork *c, const ScsCone *k) {
     scs_printf("FATAL: heev workspace query failure, info = %li\n", (long)info);
     return -1;
   }
-  c->lcwork = (blas_int)(lcwork);
+  c->lcwork = (blas_int)(creal(lcwork));
   c->lrwork = (blas_int)(lrwork);
   c->liwork = liwork;
   c->cwork = (scs_complex_float *)scs_calloc(c->lcwork, sizeof(scs_complex_float));
@@ -703,11 +703,11 @@ static scs_int proj_complex_semi_definite_cone(scs_float *X, const scs_int n,
 
   /* extract just lower triangular matrix */
   for (i = 0; i < n - 1; ++i) {
-    X[i * (2 * n - i)] = cXs[i * (n + 1)];
+    X[i * (2 * n - i)] = creal(cXs[i * (n + 1)]);
     memcpy(&(X[i * (2 * n - i) + 1]), &(cXs[i * (n + 1) + 1]),
            2 * (n - i - 1) * sizeof(scs_float));
   }
-  X[n * n - 1] = cXs[n * n - 1];
+  X[n * n - 1] = creal(cXs[n * n - 1]);
   return 0;
 
 #else

--- a/src/cones.c
+++ b/src/cones.c
@@ -487,7 +487,7 @@ static scs_int proj_semi_definite_cone(scs_float *X, const scs_int n,
 
 #ifdef USE_LAPACK
 
-  /* copy upper triangular matrix into full matrix */
+  /* copy lower triangular matrix into full matrix */
   for (i = 0; i < n; ++i) {
     memcpy(&(Xs[i * (n + 1)]), &(X[i * n - ((i - 1) * i) / 2]),
            (n - i) * sizeof(scs_float));
@@ -539,7 +539,7 @@ static scs_int proj_semi_definite_cone(scs_float *X, const scs_int n,
   /* undo rescaling: scale diags by 1/sqrt(2) */
   BLAS(scal)(&nb, &sqrt2_inv, Xs, &nb_plus_one); /* not n_squared */
 
-  /* extract just upper triangular matrix */
+  /* extract just lower triangular matrix */
   for (i = 0; i < n; ++i) {
     memcpy(&(X[i * n - ((i - 1) * i) / 2]), &(Xs[i * (n + 1)]),
            (n - i) * sizeof(scs_float));
@@ -648,7 +648,7 @@ static scs_int proj_complex_semi_definite_cone(scs_float *X, const scs_int n,
 
 #ifdef USE_LAPACK
 
-  /* copy upper triangular matrix into full matrix */
+  /* copy lower triangular matrix into full matrix */
   for (i = 0; i < n - 1; ++i) {
     cXs[i * (n + 1)] = X[i * (2 * n - i)];
     memcpy(&(cXs[i * (n + 1) + 1]), &(X[i * (2 * n - i) + 1]),
@@ -687,21 +687,21 @@ static scs_int proj_complex_semi_definite_cone(scs_float *X, const scs_int n,
     return 0;
   }
 
-  /*LAPACK is col-major, so the columns of cZ' are the eigenvectors */
+  /* cZ is matrix of all eigenvectors */
   /* scale cZ by sqrt(eig) */
   for (i = first_idx; i < n; ++i) {
     csq_eig_pos = SQRTF(e[i]);
     BLASC(scal)(&nb, &csq_eig_pos, &cZ[i * n], &one_int);
   }
 
-  /* Xs = Z Z' = V E V' */
+  /* Xs = cZ cZ' = V E V' */
   ncols_z = (blas_int)(n - first_idx);
   BLASC(herk)("Lower", "NoTrans", &nb, &ncols_z, &one, &cZ[first_idx * n], &nb, &zero, cXs, &nb);
 
   /* undo rescaling: scale diags by 1/sqrt(2) */
   BLASC(scal)(&nb, &csqrt2_inv, cXs, &nb_plus_one); /* not n_squared */
 
-  /* extract just upper triangular matrix */
+  /* extract just lower triangular matrix */
   for (i = 0; i < n - 1; ++i) {
     X[i * (2 * n - i)] = cXs[i * (n + 1)];
     memcpy(&(X[i * (2 * n - i) + 1]), &(cXs[i * (n + 1) + 1]),


### PR DESCRIPTION
Closes #290 

In the end I didn't use Hypatia's indexing, but something that was close to what SCS was already doing in the real case.

You can test it via the following code:
```c
#include "scs.h"    /* SCS API */
#include <stdio.h>  /* printf */
#include <stdlib.h> /* memory allocation */
#include <math.h>   // sqrt

//C = {{1, 2 + 3 I, 4 + 5 I}, {2 - 3 I, 6, 7 - 8 I}, {4 - 5 I, 7 + 8 I, 9}}, mineig -5.22892944

/* Set up and solve basic qp */
int main(int argc, char **argv) {
  /* Set up the problem data */
  /* A and P must be in compressed sparse column format */
  double A_x[12] = {1.0, -1.0, -1.0, -1.0, -1.0, -1.0, 1.0, -1.0, -1.0, -1.0, 1.0, -1.0}; //nzval
  int A_i[12] = {0,  1,  2,  3, 4, 5, 0, 6, 7, 8, 0, 9}; //rowval
  int A_p[10] = {0, 2, 3, 4, 5, 6, 8, 9, 10, 12}; //colptr
  double b[10] = {1.0, 0., 0., 0., 0., 0., 0., 0., 0., 0.};
  double c[9] = {1, 2*sqrt(2), 3*sqrt(2), 4*sqrt(2), 5*sqrt(2), 6, 7*sqrt(2), -8*sqrt(2), 9};
  /* data shapes */
  int n = 9; /* number of variables */
  int m = 10; /* number of constraints */
  int cs[] = {3};
  int cssize = 1;
  /* Allocate SCS structs */
  
  ScsCone *k = (ScsCone *)calloc(1, sizeof(ScsCone));
  ScsData *d = (ScsData *)calloc(1, sizeof(ScsData));
  ScsSettings *stgs = (ScsSettings *)calloc(1, sizeof(ScsSettings));
  ScsSolution *sol = (ScsSolution *)calloc(1, sizeof(ScsSolution));
  ScsInfo *info = (ScsInfo *)calloc(1, sizeof(ScsInfo));

  /* Fill in data struct */
  d->m = m;
  d->n = n;
  d->b = b;
  d->c = c;
  d->A = &(ScsMatrix){A_x, A_i, A_p, m, n};
  d->P = SCS_NULL; //&(ScsMatrix){P_x, P_i, P_p, n, n};

  /* Cone */
  k->z = 1;
  k->cs = cs;
  k->cssize = cssize;

  /* Utility to set default settings */
  scs_set_default_settings(stgs);

  /* Modify tolerances */
  stgs->eps_abs = 1e-9;
  stgs->eps_rel = 1e-9;

  /* Initialize SCS workspace */
  ScsWork *scs_work = scs_init(d, k, stgs);

  /* Solve! */
  int exitflag = scs_solve(scs_work, sol, info, 0);

  /*
   * If we wanted to solve many related problems with different
   * b / c vectors we could update the SCS workspace as follows:
   *
   * int success = scs_update(scs_work, new_b, new_c)
   * int new_exitflag = scs_solve(scs_work, sol, info, 1);
   *
   */

  /* Free SCS workspace */
  scs_finish(scs_work);

  /* Verify that SCS solved the problem */
  printf("SCS solved successfully: %i\n", exitflag == SCS_SOLVED);

  /* Print some info about the solve */
  printf("SCS took %i iters, using the %s linear solver.\n", info->iter,
         info->lin_sys_solver);

  /* Print solution x */
  printf("Optimal solution vector x*:\n");
  for (int i = 0; i < n; ++i) {
    printf("x[%i] = %4f\n", i, sol->x[i]);
  }

  /* Print dual solution y */
  printf("Optimal dual vector y*:\n");
  for (int i = 0; i < m; ++i) {
    printf("y[%i] = %4f\n", i, sol->y[i]);
  }

  /* Free allocated memory */
  free(k);
  free(d);
  free(stgs);
  free(info);
  /* SCS allocates sol->x,y,s if NULL on entry, need to be freed */
  free(sol->x);
  free(sol->y);
  free(sol->s);
  free(sol);
  return 0; /* returning exitflag will set bash exit code to 1 */
}
```
I didn't do benchmarking because that's just painful in C. Once it's merged I can write the Julia interface and benchmark it.
