### PR TITLE
add linear solver based on CuDSS

### DIFF
--- a/.github/workflows/cmake_cudss.yml
+++ b/.github/workflows/cmake_cudss.yml
@@ -1,0 +1,36 @@
+---
+name: Build and Test cudss
+
+on: [push, pull_request]
+
+jobs:
+  linux:
+    strategy:
+      fail-fast: false
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: Jimver/cuda-toolkit@v0.2.25
+        id: cuda-toolkit
+        with:
+          method: network
+          non-cuda-sub-packages: '["libcublas", "libcusparse", "libcudart"]'
+
+      - name: Install deps
+        run: sudo apt-get install libopenblas-dev liblapack-dev
+      - name: Install cudss
+        run: sudo apt-get -y install cudss
+
+      - name: Build SCS cudss
+        run: |
+          mkdir out
+          export INSTALL_DIR=$PWD/out
+          export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$INSTALL_DIR/lib
+          mkdir build
+          cd build
+          cmake -DBUILD_TESTING=ON -DDLONG=0 -DUSE_CUDSS=1 -DCMAKE_INSTALL_PREFIX:PATH=$INSTALL_DIR ..
+          make
+          make install
+        #   ctest --output-on-failure

--- a/.github/workflows/gpu.yml
+++ b/.github/workflows/gpu.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: Jimver/cuda-toolkit@v0.2.23
+      - uses: Jimver/cuda-toolkit@v0.2.25
         id: cuda-toolkit
         with:
           method: network

--- a/.github/workflows/gpu.yml
+++ b/.github/workflows/gpu.yml
@@ -17,3 +17,12 @@ jobs:
       - run: make gpu
       - run: make test_gpu
       # - run: out/run_tests_gpu_indirect    # gpus not available yet
+      - name: Install cudss
+        run: sudo apt-get -y install cudss
+      - name: Make cudss target
+        run: |
+          export CUDSS_PATH=/usr/lib/cudss
+          export CUCC=${CUDA_PATH}/bin/nvcc
+          ${CUCC} --version
+          make cudss
+      # - run: out/run_tests_cudss           # gpus not available yet

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -128,6 +128,10 @@ message(STATUS "BLAS/LAPACK usage is ${USE_LAPACK}")
 option(USE_OPENMP "Compile with OpenMP support" OFF)
 message(STATUS "OpenMP parallelization is ${USE_OPENMP}")
 
+# Enable cuDSS support
+option(USE_CUDSS "Compile with cuDSS support" OFF)
+message(STATUS "cuDSS support is ${USE_CUDSS}")
+
 set(COMPILER_OPTS "-DCTRLC")
 set(LAPACK_LINK_LIBRARIES "")
 
@@ -389,6 +393,76 @@ endif()
 
 # ##############################################################################
 
+# If cuDSS is enabled and environment variables are set, install the cuDSS version
+if(USE_CUDSS)
+  find_package(CUDAToolkit REQUIRED)
+  find_package(cudss REQUIRED)
+
+  # Force 32-bit integers for cuDSS compatibility
+  if(DLONG)
+    message(FATAL_ERROR "cuDSS requires 32-bit integers. Set DLONG=OFF or do not use -DDLONG=ON")
+  endif()
+
+  message(STATUS "Will install SCS-cuDSS (libscscudss).")
+
+
+  set(CUDSSSRC ${LINSYS}/cudss/direct)
+
+  # Here we compile the direct cuDSS library
+  set(${PROJECT_NAME}_CUDSS ${PROJECT_NAME}cudss)
+  add_library(
+    ${${PROJECT_NAME}_CUDSS}
+    ${${PROJECT_NAME}_HDR} ${${PROJECT_NAME}_SRC} ${CUDSSSRC}/private.c
+    ${CUDSSSRC}/private.h)
+
+  target_include_directories(
+    ${${PROJECT_NAME}_CUDSS}
+    PRIVATE
+      "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/${CUDSSSRC};${CMAKE_CURRENT_SOURCE_DIR}/${LINSYS}>"
+  )
+
+  target_include_directories(
+    ${${PROJECT_NAME}_CUDSS}
+    PUBLIC "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
+           "$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/scs>")
+
+  target_compile_definitions(${${PROJECT_NAME}_CUDSS} PRIVATE ${COMPILER_OPTS})
+
+
+  target_link_libraries(
+    ${${PROJECT_NAME}_CUDSS}
+    PRIVATE CUDA::cudart
+            cudss
+            $<$<NOT:$<PLATFORM_ID:Windows>>:m>
+            ${LAPACK_LINK_LIBRARIES})
+
+  # Set some properties
+  set_target_properties(
+    ${${PROJECT_NAME}_CUDSS}
+    PROPERTIES VERSION ${scs_VERSION} PUBLIC_HEADER
+                                      "${${PROJECT_NAME}_PUBLIC_HDR}")
+
+  add_library(scs::${${PROJECT_NAME}_CUDSS} ALIAS ${${PROJECT_NAME}_CUDSS})
+
+  # Install the library
+  install(
+    TARGETS ${${PROJECT_NAME}_CUDSS}
+    EXPORT ${PROJECT_NAME}
+    COMPONENT runtime
+    LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}" COMPONENT shlib
+    ARCHIVE DESTINATION "${CMAKE_INSTALL_LIBDIR}" COMPONENT lib
+    RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}" COMPONENT bin
+    PUBLIC_HEADER DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/scs")
+
+  # Add the cuDSS method to the set of the compiled targets
+  set_property(GLOBAL APPEND PROPERTY SCS_TARGETS ${${PROJECT_NAME}_CUDSS})
+elseif(USE_CUDSS)
+  message(
+    STATUS "USE_CUDSS is ON but CUDA_PATH and/or CUDSS_PATH environment variables are undefined, skipping SCS-cuDSS install"
+  )
+endif()
+
+# ##############################################################################
 # Install the .cmake file. It is possible to link scs o consumer libraries.
 include(InstallBasicPackageFiles)
 install_basic_package_files(
@@ -448,6 +522,22 @@ if(BUILD_TESTING)
     add_test(
       NAME run_tests_mkl
       COMMAND run_tests_mkl
+      WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
+  endif()
+
+  if(USE_CUDSS)
+    add_executable(run_tests_cudss test/run_tests.c)
+    target_compile_definitions(run_tests_cudss PRIVATE ${COMPILER_OPTS})
+    target_link_libraries(run_tests_cudss PRIVATE scs::scscudss)
+    target_include_directories(
+      run_tests_cudss
+      PRIVATE
+        "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/test;${CMAKE_CURRENT_SOURCE_DIR}/include;${CMAKE_CURRENT_SOURCE_DIR}/${LINSYS}>"
+    )
+
+    add_test(
+      NAME run_tests_cudss
+      COMMAND run_tests_cudss
       WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
   endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -456,10 +456,6 @@ if(USE_CUDSS)
 
   # Add the cuDSS method to the set of the compiled targets
   set_property(GLOBAL APPEND PROPERTY SCS_TARGETS ${${PROJECT_NAME}_CUDSS})
-elseif(USE_CUDSS)
-  message(
-    STATUS "USE_CUDSS is ON but CUDA_PATH and/or CUDSS_PATH environment variables are undefined, skipping SCS-cuDSS install"
-  )
 endif()
 
 # ##############################################################################

--- a/Makefile
+++ b/Makefile
@@ -51,6 +51,8 @@ src/scs_version.o: src/scs_version.c $(INC_FILES)
 $(DIRSRC)/private.o: $(DIRSRC)/private.c  $(DIRSRC)/private.h
 $(INDIRSRC)/indirect/private.o: $(INDIRSRC)/private.c $(INDIRSRC)/private.h
 $(MKLSRC)/private.o: $(MKLSRC)/private.c  $(MKLSRC)/private.h
+$(CUDSSSRC)/private.o: $(CUDSSSRC)/private.c  $(CUDSSSRC)/private.h
+	$(CUCC) $(INCLUDE) $(CUDSS_FLAGS) -I$(CUDSSSRC) -c $(CUDSSSRC)/private.c -o $@
 $(LINSYS)/scs_matrix.o: $(LINSYS)/scs_matrix.c $(LINSYS)/scs_matrix.h
 $(LINSYS)/csparse.o: $(LINSYS)/csparse.c $(LINSYS)/csparse.h
 
@@ -69,6 +71,11 @@ $(OUT)/libscsmkl.a: $(SCS_O) $(SCS_OBJECTS) $(MKLSRC)/private.o $(LINSYS)/scs_ma
 	$(ARCHIVE) $@ $^
 	- $(RANLIB) $@
 
+$(OUT)/libscscudss.a: $(SCS_O) $(SCS_OBJECTS) $(CUDSSSRC)/private.o $(LINSYS)/scs_matrix.o $(LINSYS)/csparse.o
+	mkdir -p $(OUT)
+	$(ARCHIVE) $@ $^
+	- $(RANLIB) $@
+
 $(OUT)/libscsdir.$(SHARED): $(SCS_O) $(SCS_OBJECTS) $(DIRSRC)/private.o $(AMD_OBJS) $(LDL_OBJS) $(LINSYS)/scs_matrix.o $(LINSYS)/csparse.o
 	mkdir -p $(OUT)
 	$(CC) $(CFLAGS) -shared -Wl,$(SONAME),$(@:$(OUT)/%=%) -o $@ $^ $(LDFLAGS) $(BLASLDFLAGS)
@@ -81,6 +88,10 @@ $(OUT)/libscsmkl.$(SHARED): $(SCS_O) $(SCS_OBJECTS) $(MKLSRC)/private.o $(LINSYS
 	mkdir -p $(OUT)
 	$(CC) $(CFLAGS) -shared -Wl,$(SONAME),$(@:$(OUT)/%=%) -o $@ $^ $(LDFLAGS) $(MKLFLAGS)
 
+$(OUT)/libscscudss.$(SHARED): $(SCS_O) $(SCS_OBJECTS) $(CUDSSSRC)/private.o $(LINSYS)/scs_matrix.o $(LINSYS)/csparse.o
+	mkdir -p $(OUT)
+	$(CC) $(CFLAGS) -shared -Wl,$(SONAME),$(@:$(OUT)/%=%) -o $@ $^ $(LDFLAGS) $(CULDFLAGS)
+
 $(OUT)/demo_socp_direct: test/random_socp_prob.c $(OUT)/libscsdir.a
 	$(CC) $(CFLAGS) -o $@ $^ $(LDFLAGS) $(BLASLDFLAGS)
 
@@ -89,6 +100,9 @@ $(OUT)/demo_socp_indirect: test/random_socp_prob.c $(OUT)/libscsindir.a
 
 $(OUT)/demo_socp_mkl: test/random_socp_prob.c $(OUT)/libscsmkl.a
 	$(CC) $(CFLAGS) -o $@ $^ $(LDFLAGS) $(MKLFLAGS)
+
+$(OUT)/demo_socp_cudss: test/random_socp_prob.c $(OUT)/libscscudss.a
+	$(CC) $(CFLAGS) -o $@ $^ $(LDFLAGS) $(BLASLDFLAGS) $(CUDSS_LDFLAGS)
 
 $(OUT)/run_from_file_direct: test/run_from_file.c $(OUT)/libscsdir.a
 	$(CC) $(CFLAGS) -o $@ $^ $(LDFLAGS) $(BLASLDFLAGS)
@@ -109,6 +123,8 @@ $(OUT)/run_tests_direct: test/run_tests.c $(OUT)/libscsdir.a
 $(OUT)/run_tests_mkl: test/run_tests.c $(OUT)/libscsmkl.a
 	$(CC) $(CFLAGS) -o $@ $^ $(LDFLAGS) $(MKLFLAGS) -Itest
 
+$(OUT)/run_tests_cudss: test/run_tests.c $(OUT)/libscscudss.a
+	$(CC) $(CFLAGS) -o $@ $^ $(LDFLAGS) $(BLASLDFLAGS) $(CUDSS_LDFLAGS) -Itest
 
 .PHONY: test_gpu
 test_gpu: $(OUT)/run_tests_gpu_indirect # $(OUT)/run_tests_gpu_direct
@@ -120,6 +136,8 @@ ifndef MKLROOT
 	$(error MKLROOT is undefined, set MKLROOT to the MKL install location)
 endif
 
+.PHONY:
+cudss: $(OUT)/libscscudss.a $(OUT)/libscscudss.$(SHARED) $(OUT)/run_tests_cudss $(OUT)/demo_socp_cudss
 
 $(OUT)/run_tests_gpu_indirect: test/run_tests.c $(OUT)/libscsgpuindir.a
 	$(CC) $(CFLAGS) -o $@ $^ $(LDFLAGS) $(BLASLDFLAGS) $(CULDFLAGS) -Itest
@@ -134,13 +152,13 @@ gpu: gpu_indirect # gpu_direct
 gpu_indirect: $(OUT)/demo_socp_gpu_indirect $(OUT)/libscsgpuindir.$(SHARED) $(OUT)/libscsgpuindir.a $(OUT)/run_from_file_gpu_indirect
 
 $(LINSYS)/gpu/gpu.o: $(LINSYS)/gpu/gpu.c
-	$(CUCC) -c -o $@ $^ $(CUDAFLAGS)
+	$(CC) -c -o $@ $^ $(CUDAFLAGS)
 
 # $(GPUDIR)/private.o: $(GPUDIR)/private.c
 # 	$(CUCC) -c -o $(GPUDIR)/private.o $^ $(CUDAFLAGS)
 
 $(GPUINDIR)/private.o: $(GPUINDIR)/private.c
-	$(CUCC) -c -o $@ $^ $(CUDAFLAGS)
+	$(CC) -c -o $@ $^ $(CUDAFLAGS)
 
 # $(OUT)/libscsgpudir.$(SHARED): $(SCS_O) $(SCS_OBJECTS) $(GPUDIR)/private.o $(AMD_OBJS) $(LINSYS)/scs_matrix.o $(LINSYS)/gpu/gpu.o
 #	 mkdir -p $(OUT)

--- a/docs/src/contributing/index.rst
+++ b/docs/src/contributing/index.rst
@@ -13,7 +13,6 @@ Here are some ideas (of varying difficulty):
 * Improve the :ref:`data equilibration <equilibration>`
 * Improve the :ref:`heuristic re-scaling <updating_scale>`
 * Determine how to select the :code:`TAU_FACTOR` :ref:`term <scaling>`
-* Implement a :ref:`GPU direct linear system solver <gpu_indirect>`
 * Add other new :ref:`linear system solvers <new_linear_solver>`
 * Refactor the :ref:`linear solvers <linear_solver>` to only compile a single binary with all solvers
 * Add :ref:`interfaces for other languages <interfaces>` (or improve the current interfaces)

--- a/docs/src/install/c.rst
+++ b/docs/src/install/c.rst
@@ -66,6 +66,20 @@ MKL compiler flags might not be right for your system and may need to be
 <https://www.intel.com/content/www/us/en/developer/tools/oneapi/onemkl-link-line-advisor.html>`_).
 
 
+If you have a GPU and CUDA toolkit installed, along with the
+`cuDSS <https://developer.nvidia.com/cudss>`_ library, you can compile SCS
+with cuDSS support using CMake. First, ensure that the :code:`CUDA_PATH` and
+:code:`CUDSS_PATH` environment variables are set, then configure with cuDSS enabled:
+
+.. code:: bash
+
+  cmake -DCMAKE_INSTALL_PREFIX:PATH=<custom-folder> -DUSE_CUDSS=ON -DDLONG=OFF ../
+  make
+
+Currently cuDSS only supports 32 bit integers (for sparse matrix idicies) so
+:code:`DDLONG=OFF` is mandatory.
+This will build and install the cuDSS linear solver with target :code:`scs::scscudss`.
+
 The libraries can be imported using the find_package CMake command and used
 by calling target_link_libraries as in the following example:
 
@@ -84,6 +98,9 @@ by calling target_link_libraries as in the following example:
 
   # To use the MKL Pardiso direct method
   target_link_libraries(example scs::scsmkl)
+
+  # To use the cuDSS direct method
+  target_link_libraries(example scs::scscudss)
 
 Makefile
 ^^^^^^^^

--- a/docs/src/install/c.rst
+++ b/docs/src/install/c.rst
@@ -137,6 +137,20 @@ binaries in the out folder corresponding to the GPU version.  Note that the GPU
   make gpu DLONG=0
   out/run_tests_gpu_indirect
 
+Finally, to compile and test the :ref:`cuDSS solver <cudss>` you need to have
+CUDA toolkit, the :code:`nvcc` compiler, and
+`cuDSS <https://developer.nvidia.com/cudss>`_ library installed.
+Then set :code:`CUDA_PATH` and :code:`CUDSS_PATH` and execute
+
+.. code::bash
+
+  make cudss DLONG=0
+  out/run_tests_cudss
+
+Currently cuDSS only supports 32 bit integers (for sparse matrix idicies) so
+:code:`DLONG=0` is mandatory (see `the docs of cuDSS CSR matrix
+<https://docs.nvidia.com/cuda/cudss/functions.html#cudssmatrixcreatecsr>`_).
+
 To use the libraries in your own source code, compile your code with the linker
 option :code:`-L(PATH_TO_SCS_LIBS)` and :code:`-lscsdir` or :code:`-lscsindir`
 (as needed). The API and required data structures are defined in the file

--- a/docs/src/linear_solver/index.rst
+++ b/docs/src/linear_solver/index.rst
@@ -104,6 +104,23 @@ The above linear solvers all run on CPU. We also have support for a GPU version
 of the indirect solver, where the matrix multiplies are all performed on the
 GPU.
 
+.. _cudss:
+
+Sparse GPU direct method
+^^^^^^^^^^^^^^^^^^^^^^^^^
+
+This is a linear solver that uses the `cuDSS<https://developer.nvidia.com/cudss>`_
+library to solve the linear system on the GPU. It is similar to the direct
+solver, but uses the calls to cuDSS library to perform the analysis, numerical
+(re-)factorization and subsequent solves. According to its documentation
+
+> reordering (a major part of the analysis phase) is executed on the host,
+> while symbolic factorization (another part of the analysis phase),
+> numerical factorization and solve are executed on the GPU.
+
+As the newest addition to SCS this solver is still under development and not
+as well battle-tested as the other solvers.
+
 .. _new_linear_solver:
 
 Implementing a new linear solver

--- a/linsys/cudss/direct/private.c
+++ b/linsys/cudss/direct/private.c
@@ -1,0 +1,275 @@
+#include "private.h"
+#include "linsys.h"
+
+/* In case of error abort freeing p */
+#define CUDSS_CHECK_ABORT(call, p, fname)                                 \
+  do                                                                      \
+  {                                                                       \
+    cudssStatus_t status = call;                                          \
+    if (status != CUDSS_STATUS_SUCCESS)                                   \
+    {                                                                     \
+      scs_printf("CUDSS call " #fname " returned status = %d\n", status); \
+      scs_free_lin_sys_work(p);                                           \
+      return SCS_NULL;                                                    \
+    }                                                                     \
+  } while (0);
+
+/* In case of error abort freeing p */
+#define CUDA_CHECK_ABORT(call, p, fname)                             \
+  do                                                                 \
+  {                                                                  \
+    cudaError_t status = call;                                       \
+    if (status != cudaSuccess)                                       \
+    {                                                                \
+      printf("CUDA call " #fname " returned status = %d\n", status); \
+      scs_free_lin_sys_work(p);                                      \
+      return SCS_NULL;                                               \
+    }                                                                \
+  } while (0);
+
+/* Return the linear system method name */
+const char *scs_get_lin_sys_method()
+{
+  return "sparse-direct-cuDSS";
+}
+
+/* Free allocated resources for the linear system solver */
+void scs_free_lin_sys_work(ScsLinSysWork *p)
+{
+  if (p)
+  {
+    /* Free GPU resources */
+    if (p->d_kkt_val)
+      cudaFree(p->d_kkt_val);
+    if (p->d_kkt_row_ptr)
+      cudaFree(p->d_kkt_row_ptr);
+    if (p->d_kkt_col_ind)
+      cudaFree(p->d_kkt_col_ind);
+    if (p->d_b)
+      cudaFree(p->d_b);
+    if (p->d_sol)
+      cudaFree(p->d_sol);
+
+    /* Free cuDSS resources */
+    if (p->d_kkt_mat)
+      cudssMatrixDestroy(p->d_kkt_mat);
+    if (p->d_b_mat)
+      cudssMatrixDestroy(p->d_b_mat);
+    if (p->d_sol_mat)
+      cudssMatrixDestroy(p->d_sol_mat);
+
+    if (p->solver_config)
+      cudssConfigDestroy(p->solver_config);
+    if (p->solver_data && p->handle)
+      cudssDataDestroy(p->handle, p->solver_data);
+    if (p->handle)
+      cudssDestroy(p->handle);
+
+    /* Free CPU resources */
+    if (p->kkt)
+      SCS(cs_spfree)(p->kkt);
+    if (p->sol)
+      scs_free(p->sol);
+    if (p->diag_r_idxs)
+      scs_free(p->diag_r_idxs);
+    if (p->diag_p)
+      scs_free(p->diag_p);
+
+    scs_free(p);
+  }
+}
+
+/* Initialize the linear system solver workspace */
+ScsLinSysWork *scs_init_lin_sys_work(const ScsMatrix *A, const ScsMatrix *P,
+                                     const scs_float *diag_r)
+{
+  ScsLinSysWork *p = scs_calloc(1, sizeof(ScsLinSysWork));
+  if (!p)
+    return SCS_NULL;
+
+  /* Store problem dimensions */
+  p->n = A->n;
+  p->m = A->m;
+  p->n_plus_m = p->n + p->m;
+
+  /* Allocate CPU memory */
+  p->sol = (scs_float *)scs_malloc(sizeof(scs_float) * p->n_plus_m);
+  if (!p->sol)
+  {
+    scs_free_lin_sys_work(p);
+    return SCS_NULL;
+  }
+
+  p->diag_r_idxs = (scs_int *)scs_calloc(p->n_plus_m, sizeof(scs_int));
+  if (!p->diag_r_idxs)
+  {
+    scs_free_lin_sys_work(p);
+    return SCS_NULL;
+  }
+
+  p->diag_p = (scs_float *)scs_calloc(p->n, sizeof(scs_float));
+  if (!p->diag_p)
+  {
+    scs_free_lin_sys_work(p);
+    return SCS_NULL;
+  }
+
+  /* Form KKT matrix as upper-triangular, CSC */
+  /* Because of symmetry it is equivalent to lower-triangular, CSR */
+  p->kkt = SCS(form_kkt)(A, P, p->diag_p, diag_r, p->diag_r_idxs, 1);
+  if (!p->kkt)
+  {
+    scs_printf("Error in forming KKT matrix");
+    scs_free_lin_sys_work(p);
+    return SCS_NULL;
+  }
+
+  cudssStatus_t status;
+  cudaError_t cuda_error;
+
+  /* Create cuDSS handle */
+  CUDSS_CHECK_ABORT(cudssCreate(&p->handle), p, "cudssCreate");
+  /* Creating cuDSS solver configuration and data objects */
+
+  CUDSS_CHECK_ABORT(cudssConfigCreate(&p->solver_config), p, "cudssConfigCreate");
+  CUDSS_CHECK_ABORT(cudssDataCreate(p->handle, &p->solver_data), p, "cudssDataCreate");
+
+  /* Allocate device memory for KKT matrix */
+  scs_int nnz = p->kkt->p[p->n_plus_m];
+
+  CUDA_CHECK_ABORT(cudaMalloc((void **)&p->d_kkt_val, nnz * sizeof(scs_float)), p, "cudaMalloc: kkt_val");
+  CUDA_CHECK_ABORT(cudaMalloc((void **)&p->d_kkt_row_ptr, (p->n_plus_m + 1) * sizeof(scs_int)), p, "cudaMalloc: kkt_row_ptr");
+  CUDA_CHECK_ABORT(cudaMalloc((void **)&p->d_kkt_col_ind, nnz * sizeof(scs_int)), p, "cudaMalloc: kkt_col_ind");
+
+  /* Copy KKT matrix to device */
+  /* Note: we treat column pointers (p->kkt->p) as row pointers on the device */
+  CUDA_CHECK_ABORT(cudaMemcpy(p->d_kkt_val, p->kkt->x, nnz * sizeof(scs_float),
+                              cudaMemcpyHostToDevice),
+                   p, "cudaMemcpy: kkt_val");
+  CUDA_CHECK_ABORT(cudaMemcpy(p->d_kkt_row_ptr, p->kkt->p, (p->kkt->n + 1) * sizeof(scs_int),
+                              cudaMemcpyHostToDevice),
+                   p, "cudaMemcpy: kkt_row_ptr");
+  CUDA_CHECK_ABORT(cudaMemcpy(p->d_kkt_col_ind, p->kkt->i, nnz * sizeof(scs_int),
+                              cudaMemcpyHostToDevice),
+                   p, "cudaMemcpy: kkt_col_ind");
+
+  /* Create kkt matrix descriptor */
+  /* We pass the kkt matrix as symmetric, lower triangular */
+  cudssMatrixType_t mtype = CUDSS_MTYPE_SYMMETRIC;
+  cudssMatrixViewType_t mview = CUDSS_MVIEW_LOWER;
+  cudssIndexBase_t base = CUDSS_BASE_ZERO;
+  CUDSS_CHECK_ABORT(cudssMatrixCreateCsr(&p->d_kkt_mat, p->kkt->m, p->kkt->n, nnz, p->d_kkt_row_ptr,
+                                         NULL, p->d_kkt_col_ind, p->d_kkt_val, SCS_CUDA_INDEX, SCS_CUDA_FLOAT,
+                                         mtype, mview, base),
+                    p, "cudssMatrixCreateCsr");
+
+  /* Allocate device memory for vectors */
+  CUDA_CHECK_ABORT(cudaMalloc((void **)&p->d_b, p->n_plus_m * sizeof(scs_float)), p, "cudaMalloc: b");
+  CUDA_CHECK_ABORT(cudaMalloc((void **)&p->d_sol, p->n_plus_m * sizeof(scs_float)), p, "cudaMalloc: sol");
+
+  /* Create RHS and solution matrix descriptors */
+  scs_int nrhs = 1;
+  CUDSS_CHECK_ABORT(cudssMatrixCreateDn(&p->d_b_mat, p->n_plus_m, nrhs, p->n_plus_m, p->d_b,
+                                        SCS_CUDA_FLOAT, CUDSS_LAYOUT_COL_MAJOR),
+                    p, "cudssMatrixCreateDn: b");
+  CUDSS_CHECK_ABORT(cudssMatrixCreateDn(&p->d_sol_mat, p->n_plus_m, nrhs, p->n_plus_m, p->d_sol,
+                                        SCS_CUDA_FLOAT, CUDSS_LAYOUT_COL_MAJOR),
+                    p, "cudssMatrixCreateDn: sol");
+
+  /* Symbolic factorization */
+  CUDSS_CHECK_ABORT(cudssExecute(p->handle, CUDSS_PHASE_ANALYSIS, p->solver_config, p->solver_data,
+                                 p->d_kkt_mat, p->d_sol_mat, p->d_b_mat),
+                    p, "cudssExecute: analysis");
+
+  /* Numerical Factorization */
+  CUDSS_CHECK_ABORT(cudssExecute(p->handle, CUDSS_PHASE_FACTORIZATION, p->solver_config, p->solver_data,
+                                 p->d_kkt_mat, p->d_sol_mat, p->d_b_mat),
+                    p, "cudssExecute: factorization");
+
+  return p;
+}
+
+/* Solve the linear system for a given RHS b */
+scs_int scs_solve_lin_sys(ScsLinSysWork *p, scs_float *b, const scs_float *ws,
+                          scs_float tol)
+{
+  /* Copy right-hand side to device */
+  cudaError_t custatus = cudaMemcpy(p->d_b, b, p->n_plus_m * sizeof(scs_float),
+                                    cudaMemcpyHostToDevice);
+  if (custatus != cudaSuccess)
+  {
+    scs_printf("scs_solve_lin_sys: Error copying `b` side to device: %d\n", (int)custatus);
+    return custatus;
+  }
+
+  // is this really needed?
+  cudssMatrixSetValues(p->d_b_mat, p->d_b);
+
+  /* Solve the system */
+  cudssStatus_t status = cudssExecute(p->handle, CUDSS_PHASE_SOLVE, p->solver_config, p->solver_data,
+                                      p->d_kkt_mat, p->d_sol_mat, p->d_b_mat);
+
+  if (status != CUDSS_STATUS_SUCCESS)
+  {
+    scs_printf("scs_solve_lin_sys: Error during solve: %d\n", (int)status);
+    return status;
+  }
+
+  /* Copy solution back to host */
+  custatus = cudaMemcpy(b, p->d_sol, p->n_plus_m * sizeof(scs_float),
+                        cudaMemcpyDeviceToHost);
+  if (status != cudaSuccess)
+  {
+    scs_printf("scs_solve_lin_sys: Error copying d_sol to host: %d\n", (int)status);
+    return status;
+  }
+
+  return 0; /* Success */
+}
+
+/* Update the KKT matrix when R changes */
+void scs_update_lin_sys_diag_r(ScsLinSysWork *p, const scs_float *diag_r)
+{
+  scs_int i;
+
+  /* Update KKT matrix on CPU */
+  for (i = 0; i < p->n; ++i)
+  {
+    /* top left is R_x + P */
+    p->kkt->x[p->diag_r_idxs[i]] = p->diag_p[i] + diag_r[i];
+  }
+  for (i = p->n; i < p->n + p->m; ++i)
+  {
+    /* bottom right is -R_y */
+    p->kkt->x[p->diag_r_idxs[i]] = -diag_r[i];
+  }
+
+  /* Copy updated values to device */
+  cudaError_t custatus = cudaMemcpy(p->d_kkt_val, p->kkt->x,
+                                    p->kkt->p[p->n_plus_m] * sizeof(scs_float),
+                                    cudaMemcpyHostToDevice);
+  if (custatus != cudaSuccess)
+  {
+    scs_printf("scs_update_lin_sys_diag_r: Error copying kkt->x to device: %d\n", (int)custatus);
+    return;
+  }
+
+  /* Update the matrix values in cuDSS */
+  cudssStatus_t status;
+  status = cudssMatrixSetCsrPointers(p->d_kkt_mat, p->d_kkt_row_ptr, NULL, p->d_kkt_col_ind,
+                                     p->d_kkt_val);
+  if (status != CUDSS_STATUS_SUCCESS)
+  {
+    scs_printf("scs_update_lin_sys_diag_r: Error updating kkt matrix on device: %d\n", (int)status);
+    return;
+  }
+
+  /* Perform Refactorization with the updated matrix */
+  status = cudssExecute(p->handle, CUDSS_PHASE_REFACTORIZATION, p->solver_config, p->solver_data,
+                        p->d_kkt_mat, p->d_sol_mat, p->d_b_mat);
+  if (status != CUDSS_STATUS_SUCCESS)
+  {
+    scs_printf("scs_update_lin_sys_diag_r: Error during re-factorization: %d\n", (int)status);
+    return;
+  }
+}

--- a/linsys/cudss/direct/private.h
+++ b/linsys/cudss/direct/private.h
@@ -1,0 +1,65 @@
+#ifndef PRIV_H_GUARD
+#define PRIV_H_GUARD
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+#ifndef SFLOAT
+#define SCS_CUDA_FLOAT CUDA_R_64F
+#else
+#define SCS_CUDA_FLOAT CUDA_R_32F
+#endif
+
+#ifndef DLONG
+#define SCS_CUDA_INDEX CUDA_R_32I
+#else
+#define SCS_CUDA_INDEX CUDA_R_64I
+#endif
+
+#include "csparse.h"
+#include "linsys.h"
+#include <cuda_runtime.h>
+#include <cudss.h>
+
+  struct SCS_LIN_SYS_WORK
+  {
+    /* General problem dimensions */
+    scs_int n;        /* number of QP variables */
+    scs_int m;        /* number of QP constraints */
+    scs_int n_plus_m; /* dimension of the linear system */
+
+    /* CPU matrices and vectors */
+    ScsMatrix *kkt; /* KKT matrix in CSR format */
+    scs_float *sol; /* solution to the KKT system */
+
+    /* cuDSS handle and descriptors */
+    cudssHandle_t handle;    /* cuDSS library handle */
+    cudssMatrix_t d_kkt_mat; /* cuDSS matrix descriptors */
+    cudssMatrix_t d_b_mat;
+    cudssMatrix_t d_sol_mat;
+
+    /* Device memory for KKT matrix */
+    scs_float *d_kkt_val;   /* device copy of KKT values */
+    scs_int *d_kkt_row_ptr; /* device copy of KKT row pointers */
+    scs_int *d_kkt_col_ind; /* device copy of KKT column indices */
+
+    /* Device memory for vectors */
+    scs_float *d_b;   /* device copy of right-hand side */
+    scs_float *d_sol; /* device copy of solution */
+
+    /* These are required for matrix updates */
+    scs_int *diag_r_idxs; /* indices where R appears in the KKT matrix */
+    scs_float *diag_p;    /* Diagonal values of P */
+
+    /* cuDSS configuration */
+    cudssConfig_t solver_config; /* cuDSS solver handle */
+    cudssData_t solver_data;     /* cuDSS data handle */
+  };
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/scs.mk
+++ b/scs.mk
@@ -8,7 +8,6 @@ endif
 # For cross-compiling with mingw use these.
 #CC = i686-w64-mingw32-gcc -m32
 #CC = x86_64-w64-mingw32-gcc-4.8
-CUCC = $(CC) #Don't need to use nvcc, since using cuda blas APIs
 
 # For GPU must add cuda libs to path, e.g.
 # export DYLD_LIBRARY_PATH=/usr/local/cuda/lib:$DYLD_LIBRARY_PATH
@@ -53,13 +52,19 @@ endif
 #TODO: check if this works for all platforms:
 ifeq ($(CUDA_PATH), )
 CUDA_PATH=/usr/local/cuda
+CUCC = $(CUDA_PATH)/bin/nvcc
+CUDSS_DIR=/opt/cudss
 endif
 CULDFLAGS = -L$(CUDA_PATH)/lib -L$(CUDA_PATH)/lib64 -lcudart -lcublas -lcusparse
 CUDAFLAGS = $(CFLAGS) -I$(CUDA_PATH)/include -Ilinsys/gpu -Wno-c++11-long-long # turn off annoying long-long warnings in cuda header files
 
+CUDSS_FLAGS = -I$(CUDSS_DIR)/include -I$(CUDA_PATH)/include
+CUDSS_LDFLAGS = $(CULDFLAGS) -L$(CUDSS_DIR)/lib -lcudss
+
 # Add on default CFLAGS
 OPT = -O3
-override CFLAGS += -g -Wall -Wwrite-strings -pedantic -funroll-loops -Wstrict-prototypes -I. -Iinclude -Ilinsys $(OPT)
+INCLUDE = -I. -Iinclude -Ilinsys
+override CFLAGS += -g -Wall -Wwrite-strings -pedantic -funroll-loops -Wstrict-prototypes $(INCLUDE) $(OPT)
 ifneq ($(ISWINDOWS), 1)
 override CFLAGS += -fPIC
 endif
@@ -70,6 +75,7 @@ INDIRSRC = $(LINSYS)/cpu/indirect
 GPUDIR = $(LINSYS)/gpu/direct
 GPUINDIR = $(LINSYS)/gpu/indirect
 MKLSRC = $(LINSYS)/mkl/direct
+CUDSSSRC = $(LINSYS)/cudss/direct
 
 EXTSRC = $(LINSYS)/external
 

--- a/scs.mk
+++ b/scs.mk
@@ -53,13 +53,13 @@ endif
 ifeq ($(CUDA_PATH), )
 CUDA_PATH=/usr/local/cuda
 CUCC = $(CUDA_PATH)/bin/nvcc
-CUDSS_DIR=/opt/cudss
 endif
+
 CULDFLAGS = -L$(CUDA_PATH)/lib -L$(CUDA_PATH)/lib64 -lcudart -lcublas -lcusparse
 CUDAFLAGS = $(CFLAGS) -I$(CUDA_PATH)/include -Ilinsys/gpu -Wno-c++11-long-long # turn off annoying long-long warnings in cuda header files
 
-CUDSS_FLAGS = -I$(CUDSS_DIR)/include -I$(CUDA_PATH)/include
-CUDSS_LDFLAGS = $(CULDFLAGS) -L$(CUDSS_DIR)/lib -lcudss
+CUDSS_FLAGS = -I$(CUDSS_PATH)/include -I$(CUDA_PATH)/include
+CUDSS_LDFLAGS = $(CULDFLAGS) -L$(CUDSS_PATH)/lib -lcudss
 
 # Add on default CFLAGS
 OPT = -O3


### PR DESCRIPTION
@bodono This is an experimental version of the cuDSS-based linear solver for scs.
The structure follows mostly MKL solver.

Locally `run_tests_cudss` passes.

Please do not trust the CMake code (a0febd7), it is 100% llm-generated as I have no experience with this build system. Maybe @h-vetinari or @traversaro could chip in and review this part?
If not, we could just revert a0febd7 for now.

closes: #308
related: #162