### PR TITLE
Fixes rendering of cuDSS docs

### DIFF
--- a/docs/src/install/c.rst
+++ b/docs/src/install/c.rst
@@ -159,7 +159,7 @@ CUDA toolkit, the :code:`nvcc` compiler, and
 `cuDSS <https://developer.nvidia.com/cudss>`_ library installed.
 Then set :code:`CUDA_PATH` and :code:`CUDSS_PATH` and execute
 
-.. code::bash
+.. code:: bash
 
   make cudss DLONG=0
   out/run_tests_cudss


### PR DESCRIPTION
There's a missing space that causes the compiling instructions to not render.