### PR TITLE
docs: update MATLAB solver backends for matlab_ldl default

### DIFF
--- a/docs/src/api/matlab.rst
+++ b/docs/src/api/matlab.rst
@@ -33,14 +33,15 @@ and :code:`y` corresponds to the dual solution guess.
 Solver backends
 ---------------
 
-By default SCS uses the sparse direct (LDL) solver. Alternative backends can be
-selected via the :code:`settings` struct:
+By default SCS uses the bundled QDLDL sparse direct solver. Alternative backends
+can be selected via the :code:`settings` struct:
 
 .. code:: matlab
 
-  settings.use_indirect = true;  % conjugate gradient solver
-  settings.dense = true;         % dense Cholesky (best for dense A)
-  settings.gpu = true;           % GPU solver
+  settings.use_matlab_ldl = true;  % MATLAB's built-in LDL (MA57, no compilation needed)
+  settings.use_indirect = true;    % conjugate gradient solver
+  settings.dense = true;           % dense Cholesky (best for dense A)
+  settings.gpu = true;             % GPU solver
 
 Spectral cones
 ---------------

--- a/docs/src/api/matlab.rst
+++ b/docs/src/api/matlab.rst
@@ -33,12 +33,12 @@ and :code:`y` corresponds to the dual solution guess.
 Solver backends
 ---------------
 
-By default SCS uses the bundled QDLDL sparse direct solver. Alternative backends
-can be selected via the :code:`settings` struct:
+By default SCS uses MATLAB's built-in sparse LDL factorization (MA57 under
+the hood). Alternative backends can be selected via the :code:`settings` struct:
 
 .. code:: matlab
 
-  settings.use_matlab_ldl = true;  % MATLAB's built-in LDL (MA57, no compilation needed)
+  settings.use_qdldl = true;       % bundled QDLDL sparse direct solver
   settings.use_indirect = true;    % conjugate gradient solver
   settings.dense = true;           % dense Cholesky (best for dense A)
   settings.gpu = true;             % GPU solver

--- a/docs/src/examples/qp.m
+++ b/docs/src/examples/qp.m
@@ -1,6 +1,3 @@
-% First, make sure SCS is in the path so MATLAB can call it
-addpath("/Users/bodonoghue/git/scs-matlab")
-
 % Set up data
 data.P = sparse([3., -1.; -1., 2.]);
 data.A = sparse([-1., 1.; 1., 0.; 0., 1.]);

--- a/docs/src/install/matlab.rst
+++ b/docs/src/install/matlab.rst
@@ -3,23 +3,38 @@
 MATLAB
 ======
 
-To install SCS in Matlab from source:
+The easiest way to install SCS in MATLAB is via the pre-compiled toolbox file.
+
+Download Toolbox (.mltbx) - Recommended
+---------------------------------------
+
+The pre-compiled MATLAB Toolbox file includes binaries for Windows, Linux, and Apple Silicon Macs.
+
+1. Go to the `SCS MATLAB interface releases <https://github.com/bodono/scs-matlab/releases>`_ page.
+2. Download the latest ``SCS.mltbx`` file.
+3. Open the file in MATLAB (or double-click it) to install.
+
+Build from Source
+-----------------
+
+If you are on an unsupported platform or prefer to build from source:
+
+1. Clone the repository recursively:
 
 .. code:: bash
 
   git clone --recursive https://github.com/bodono/scs-matlab.git
 
-Then in a Matlab session
+2. In a MATLAB session:
 
 .. code:: matlab
 
   cd <path/to/scs-matlab>
   make_scs
 
-The installer automatically adds scs-matlab to your Matlab path and calls
+The installer automatically adds scs-matlab to your MATLAB path and calls
 ``savepath`` so it persists across sessions. If ``savepath`` fails (e.g., due to
 file permissions) it will print the ``addpath`` line you need to add to your
 ``startup.m``.
 
 See :ref:`here <matlab_interface>` for the API.
-


### PR DESCRIPTION
## Summary
- Update MATLAB API docs to reflect that the default linear system solver is now MATLAB's built-in sparse LDL factorization (MA57)
- Document `use_qdldl` as an explicit setting to select the bundled QDLDL solver

This accompanies bodono/scs-matlab#29 which adds the MATLAB LDL backend.

🤖 Generated with [Claude Code](https://claude.com/claude-code)