### PR TITLE
Expose Anderson acceleration stats in solve info

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -198,7 +198,7 @@ configure_file(${CMAKE_CURRENT_SOURCE_DIR}/cmake/scs_types.h.in
                ${CMAKE_CURRENT_SOURCE_DIR}/include/scs_types.h NEWLINE_STYLE LF)
 
 # Public headers
-set(${PROJECT_NAME}_PUBLIC_HDR include/scs_types.h include/scs.h)
+set(${PROJECT_NAME}_PUBLIC_HDR include/aa_stats.h include/scs_types.h include/scs.h)
 
 # Common source files
 set(${PROJECT_NAME}_SRC
@@ -235,6 +235,7 @@ endif()
 # Common header files
 set(${PROJECT_NAME}_HDR
     include/aa.h
+    include/aa_stats.h
     include/cones.h
     include/ctrlc.h
     include/glbopts.h

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ nuclear norm, sum-of-largest eigenvalues).
 
 - Multiple linear solver backends: sparse direct (QDLDL), dense direct (LAPACK),
   iterative (CG), Intel MKL Pardiso, Apple Accelerate (macOS), NVIDIA cuDSS, GPU
-- Anderson acceleration for faster convergence
+- Anderson acceleration for faster convergence, including solve diagnostics
 - Problem data normalization/equilibration for numerical stability
 - Warm-starting and incremental `b`/`c` updates via `scs_update`
 - Ctrl-C signal handling for graceful interruption

--- a/docs/src/algorithm/acceleration.rst
+++ b/docs/src/algorithm/acceleration.rst
@@ -156,6 +156,11 @@ linearly dependent near convergence. An SVD-based solve would be similarly
 rank-revealing but is substantially more expensive per iteration and has not
 been benchmarked here.
 
+SCS reports detailed AA solve diagnostics in the :code:`aa_stats` field of the
+returned :ref:`info` object. These include solve acceptances, rejection causes,
+the rank of the most recent AA solve, the most recent AA weight norm, and the
+regularization used in that solve.
+
 Regularization
 """"""""""""""
 

--- a/docs/src/api/c.rst
+++ b/docs/src/api/c.rst
@@ -134,9 +134,11 @@ See :ref:`info` for details on each of these.
 .. doxygenstruct:: ScsInfo
    :members:
 
+.. doxygenstruct:: AaStats
+   :members:
+
 Workspace
 ---------
 
 The user should not need to interact with the :code:`ScsWork` struct,
 which contains the internal workspace allocated and maintained by SCS.
-

--- a/docs/src/api/info.rst
+++ b/docs/src/api/info.rst
@@ -70,6 +70,9 @@ the following fields.
    * - :code:`accepted_accel_steps`
      - :code:`scs_int`
      - Number of times an AA update was accepted by the safeguarding check (see :ref:`acceleration`)
+   * - :code:`aa_stats`
+     - :code:`AaStats`
+     - Detailed AA solve diagnostics, including rejection causes, last rank, last weight norm, and last regularization
    * - :code:`lin_sys_time`
      - :code:`scs_float`
      - Total time (milliseconds) spent in the :ref:`linear system solver <linear_solver>`
@@ -80,3 +83,47 @@ the following fields.
      - :code:`scs_float`
      - Total time (milliseconds) spent in the :ref:`acceleration routine <acceleration>`
 
+Anderson acceleration statistics
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The :code:`aa_stats` field contains detailed diagnostics from the Anderson
+acceleration linear solves. These counters are useful for diagnosing whether AA
+is active and, when AA updates are rejected, why they were rejected.
+
+.. list-table::
+   :widths: 25 15 60
+   :header-rows: 1
+
+   * - Name
+     - Type
+     - Description
+   * - :code:`iter`
+     - :code:`scs_int`
+     - Internal AA iteration counter
+   * - :code:`n_accept`
+     - :code:`scs_int`
+     - Number of AA updates accepted by :code:`aa_apply` before safeguarding
+   * - :code:`n_reject_lapack`
+     - :code:`scs_int`
+     - Number of AA updates rejected because the LAPACK solve failed
+   * - :code:`n_reject_rank0`
+     - :code:`scs_int`
+     - Number of AA updates rejected because rank truncation produced rank zero
+   * - :code:`n_reject_nonfinite`
+     - :code:`scs_int`
+     - Number of AA updates rejected because the AA weight norm was non-finite
+   * - :code:`n_reject_weight_cap`
+     - :code:`scs_int`
+     - Number of AA updates rejected because the AA weight norm exceeded the configured cap
+   * - :code:`n_safeguard_reject`
+     - :code:`scs_int`
+     - Number of AA updates rejected by the safeguarding check
+   * - :code:`last_rank`
+     - :code:`scs_int`
+     - Rank used in the most recent AA solve
+   * - :code:`last_aa_norm`
+     - :code:`scs_float`
+     - AA weight norm from the most recent AA solve, or NaN if no AA solve was attempted
+   * - :code:`last_regularization`
+     - :code:`scs_float`
+     - Regularization value used in the most recent AA solve

--- a/docs/src/api/python.rst
+++ b/docs/src/api/python.rst
@@ -133,7 +133,8 @@ the warm-start.
 At termination :code:`sol` is a dict with fields :code:`x, y, s, info` where
 :code:`x, y, s` contains the primal-dual :ref:`solution <optimality>` or the
 :ref:`certificate of infeasibility <infeasibility>`, and :code:`info` is a dict
-containing the solve :ref:`info`.
+containing the solve :ref:`info`. Detailed Anderson acceleration diagnostics are
+available in :code:`sol["info"]["aa_stats"]`.
 
 To re-use the workspace and solve a similar problem with new :code:`b`
 and / or :code:`c` data, we can update the solver using:
@@ -142,5 +143,4 @@ and / or :code:`c` data, we can update the solver using:
 
    solver.update(b=new_b, c=new_c)  # update b and c vectors (can be None)
    solver.solve()  # solve new problem with updated b and c
-
 

--- a/include/aa.h
+++ b/include/aa.h
@@ -11,6 +11,7 @@
 extern "C" {
 #endif
 
+#include "aa_stats.h"
 #include "glbopts.h"
 
 typedef scs_float aa_float;
@@ -127,36 +128,6 @@ void aa_finish(AaWork *a);
  *
  */
 void aa_reset(AaWork *a);
-
-/**
- * Lifetime diagnostics for an AaWork. Counters accumulate from
- * aa_init and are NOT cleared by aa_reset (which is also called
- * internally when a safeguard rejection forces a fresh state, and
- * you still want the rejection itself to show up in the counts).
- *
- * Rejection causes are split so a caller can tell what needs tuning:
- *   - n_reject_lapack       geqp3 returned non-zero info (rare; linear-algebra internal failure)
- *   - n_reject_rank0        pivoted QR truncated to rank 0 (matrix numerically zero, e.g. at convergence)
- *   - n_reject_nonfinite    ||γ||₂ was NaN/Inf (extreme ill-conditioning, raise regularization)
- *   - n_reject_weight_cap   ||γ||₂ >= max_weight_norm (loosen cap or raise regularization)
- *
- * `last_*` fields reflect the most recent AA least-squares solve:
- *   - last_rank              rank of most recent solve; 0 if never solved or rank collapsed
- *   - last_aa_norm           ||γ||₂ on success; NaN if never solved or solve failed
- *   - last_regularization    r used in most recent solve; 0 if never solved or regularization=0
- */
-typedef struct {
-  aa_int iter;                  /* internal iteration counter */
-  aa_int n_accept;              /* aa_apply steps that were accepted */
-  aa_int n_reject_lapack;       /* geqp3 info != 0 */
-  aa_int n_reject_rank0;        /* pivoted QR rank truncated to 0 */
-  aa_int n_reject_nonfinite;    /* ||γ||₂ non-finite */
-  aa_int n_reject_weight_cap;   /* ||γ||₂ >= max_weight_norm */
-  aa_int n_safeguard_reject;    /* aa_safeguard rollbacks */
-  aa_int last_rank;
-  aa_float last_aa_norm;
-  aa_float last_regularization;
-} AaStats;
 
 /**
  * Return lifetime diagnostic counters.

--- a/include/aa_stats.h
+++ b/include/aa_stats.h
@@ -1,0 +1,47 @@
+/*
+ * Public Anderson acceleration diagnostic counters.
+ */
+
+#ifndef AA_STATS_H_GUARD
+#define AA_STATS_H_GUARD
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include "scs_types.h"
+
+/**
+ * Lifetime diagnostics for an Anderson acceleration workspace.
+ *
+ * Counters accumulate from aa_init and are not cleared by aa_reset, including
+ * internal resets after safeguard rejections. Rejection causes are split so a
+ * caller can tell what needs tuning.
+ */
+typedef struct {
+  /** Internal AA iteration counter. */
+  scs_int iter;
+  /** Number of AA updates accepted by aa_apply before safeguarding. */
+  scs_int n_accept;
+  /** Number of AA rejections due to LAPACK errors. */
+  scs_int n_reject_lapack;
+  /** Number of AA rejections due to rank-zero reduced systems. */
+  scs_int n_reject_rank0;
+  /** Number of AA rejections due to non-finite weights. */
+  scs_int n_reject_nonfinite;
+  /** Number of AA rejections due to the weight-norm cap. */
+  scs_int n_reject_weight_cap;
+  /** Number of AA steps rejected by safeguarding. */
+  scs_int n_safeguard_reject;
+  /** Rank of the most recent AA solve. */
+  scs_int last_rank;
+  /** Weight norm from the most recent AA solve. NaN if no solve was attempted. */
+  scs_float last_aa_norm;
+  /** Regularization used in the most recent AA solve. */
+  scs_float last_regularization;
+} AaStats;
+
+#ifdef __cplusplus
+}
+#endif
+#endif

--- a/include/scs.h
+++ b/include/scs.h
@@ -14,6 +14,7 @@ extern "C" {
 
 /* Contains definitions of primitive types `scs_int` and `scs_float`. */
 #include "scs_types.h"
+#include "aa_stats.h"
 
 #define SCS_NULL 0 /* NULL type */
 
@@ -218,6 +219,8 @@ typedef struct {
   scs_int rejected_accel_steps;
   /** Number of accepted AA steps. */
   scs_int accepted_accel_steps;
+  /** Detailed Anderson acceleration diagnostics. */
+  AaStats aa_stats;
   /** Total time (milliseconds) spent in the linear system solver. */
   scs_float lin_sys_time;
   /** Total time (milliseconds) spent in the cone projection. */

--- a/src/aa.c
+++ b/src/aa.c
@@ -234,7 +234,7 @@ struct ACCEL_WORK {
 
   aa_float *x_work; /* workspace (= x) for when relaxation != 1.0 */
 
-  /* Lifetime diagnostics (see AaStats in aa.h). NOT cleared by
+  /* Lifetime diagnostics (see AaStats in aa_stats.h). NOT cleared by
    * aa_reset — the internal reset path fires on safeguard rejection,
    * and you want the rejection to stay visible in the counters. */
   aa_int n_accept;

--- a/src/scs.c
+++ b/src/scs.c
@@ -79,6 +79,7 @@ static void print_summary(ScsWork *w, scs_int i, SCS(timer) * solve_timer);
 static void print_footer(ScsInfo *info);
 static void free_residuals(ScsResiduals *r);
 static ScsResiduals *init_residuals(const ScsData *d);
+static void set_info_aa_stats(ScsInfo *info, const AaWork *accel);
 static void populate_on_failure(scs_int m, scs_int n, ScsSolution *sol,
                                 ScsInfo *info, scs_int status_val,
                                 const char *msg);
@@ -299,6 +300,17 @@ static ScsResiduals *init_residuals(const ScsData *d) {
   return r;
 }
 
+static void set_info_aa_stats(ScsInfo *info, const AaWork *accel) {
+  if (!info) {
+    return;
+  }
+  memset(&info->aa_stats, 0, sizeof(info->aa_stats));
+  info->aa_stats.last_aa_norm = NAN;
+  if (accel) {
+    info->aa_stats = aa_get_stats(accel);
+  }
+}
+
 /* ==================== Error / Failure Handling ===================== */
 
 static void populate_on_failure(scs_int m, scs_int n, ScsSolution *sol,
@@ -340,6 +352,7 @@ static scs_int failure(ScsWork *w, scs_int m, scs_int n, ScsSolution *sol,
                        const char *ststr) {
   scs_int status = stint;
   populate_on_failure(m, n, sol, info, status, ststr);
+  set_info_aa_stats(info, w ? w->accel : SCS_NULL);
   scs_printf("Failure:%s\n", msg);
   scs_end_interrupt_listener();
   return status;
@@ -865,6 +878,7 @@ static void finalize(ScsWork *w, ScsSolution *sol, ScsInfo *info,
   info->scale_updates = w->scale_updates;
   info->rejected_accel_steps = w->rejected_accel_steps;
   info->accepted_accel_steps = w->accepted_accel_steps;
+  set_info_aa_stats(info, w->accel);
   info->comp_slack = ABS(sty);
 #ifdef SPECTRAL_TIMING_FLAG
   info->ave_time_matrix_cone_proj = w->cone_work->tot_time_mat_cone_proj / iter;

--- a/test/problems/test_solver_options.h
+++ b/test/problems/test_solver_options.h
@@ -123,6 +123,9 @@ static const char *test_no_acceleration(void) {
   mu_assert("test_no_acceleration: expected SCS_SOLVED", exitflag == SCS_SOLVED);
   mu_assert("test_no_acceleration: no AA steps should be accepted",
             info.accepted_accel_steps == 0);
+  mu_assert("test_no_acceleration: AA stats should be zeroed",
+            info.aa_stats.iter == 0 && info.aa_stats.n_accept == 0 &&
+                info.aa_stats.n_safeguard_reject == 0);
   fail = verify_solution_correct(d, k, stgs, &info, sol, exitflag);
 
   _OPTS_CLEANUP();


### PR DESCRIPTION
## Summary
- add a shared AaStats diagnostic type and attach it to ScsInfo as aa_stats
- populate ScsInfo.aa_stats from aa_get_stats() while preserving zero/NaN defaults when acceleration is disabled or unavailable
- document aa_stats in the C, Python, info, acceleration docs and README

## Tests
- cmake -S scs_source -B /tmp/scs-aa-cmake -DBUILD_TESTING=ON -DUSE_LAPACK=ON
- cmake --build /tmp/scs-aa-cmake --parallel 4
- ctest --test-dir /tmp/scs-aa-cmake --output-on-failure