### PR TITLE
Expose AA type/regularization/relaxation in ScsSettings

### DIFF
--- a/docs/src/algorithm/acceleration.rst
+++ b/docs/src/algorithm/acceleration.rst
@@ -129,13 +129,16 @@ In SCS
 
 In SCS both types of acceleration are available, though by default type-I is
 used since it tends to have better performance.  If you wish to use AA then set
-the :code:`acceleration_lookback` setting to a non-zero value (10 works well for
+the :code:`acceleration_lookback` setting to a positive value (10 works well for
 many problems and is the default). This setting corresponds to :math:`m`, the
 maximum number of SCS iterates that AA will use to extrapolate to the new point.
+Set :code:`acceleration_lookback` to :code:`0` to disable AA entirely.
 
-To enable type-II acceleration then set :code:`acceleration_lookback` to a
-negative value, the sign is interpreted as switching the AA type (this is mostly
-so that we can test it without fully exposing it the user).
+To select type-II acceleration set :code:`acceleration_type_1` to :code:`0`
+(the default :code:`1` selects type-I). Type-II is more numerically stable than
+type-I but typically slower; users switching to type-II usually also lower
+:code:`acceleration_regularization` (e.g. :code:`1e-12`) since the default is
+tuned for type-I.
 
 The setting :code:`acceleration_interval` controls how frequently AA is applied.
 If :code:`acceleration_interval` :math:`=k` for some integer :math:`k \geq 1`
@@ -186,6 +189,10 @@ into the matrices by appending :math:`\sqrt{\epsilon} I` to the bottom of
 :math:`S_k` or :math:`Y_k`, which is useful when using a QR or SVD decomposition
 to solve the equations.
 
+The setting :code:`acceleration_regularization` controls :math:`\epsilon`. The
+default (:code:`1e-8`) is tuned for type-I; type-II is typically run with a
+smaller value such as :code:`1e-12`.
+
 Max :math:`\gamma` norm
 """""""""""""""""""""""
 As the algorithm converges to the fixed point the matrices to be inverted
@@ -220,8 +227,9 @@ replaces the final step of AA by mixing the map inputs and outputs as follows:
 .. math::
   x^{k+1} = \beta \sum_{j=0}^{m_k}\alpha_j^k f(x^{k-m_k+j}) + (1-\beta) \sum_{j=0}^{m_k}\alpha_j^k x^{k-m_k+j}
 
-where :math:`\beta` is the :code:`relaxation` parameter, and :math:`\beta=1`
-recovers vanilla AA. This can be computed using the matrices defined above using
+where :math:`\beta` is the :code:`acceleration_relaxation` parameter, and
+:math:`\beta=1` recovers vanilla AA. This can be computed using the matrices
+defined above using
 
 .. math::
   x^{k+1} = \beta (f(x^k) - (S_k - Y_k) \gamma^k) + (1-\beta) (x^k - S_k \gamma^k)

--- a/docs/src/api/settings.rst
+++ b/docs/src/api/settings.rst
@@ -85,6 +85,21 @@ They are set in the :ref:`ScsSettings <ScsSettings>` struct.
      - Run Anderson acceleration every :code:`acceleration_interval` iterations. See :ref:`acceleration`.
      - :math:`\mathbf{N}`
      - 10
+   * - :code:`acceleration_type_1`
+     - :code:`scs_int`
+     - Whether AA uses type-I (:code:`1`) or type-II (:code:`0`). See :ref:`acceleration`.
+     - True/False
+     - 1
+   * - :code:`acceleration_regularization`
+     - :code:`scs_float`
+     - Tikhonov regularization for the AA least-squares solve. The default is tuned for type-I; type-II is typically more stable and tolerates a smaller value (e.g. :code:`1e-12`). See :ref:`acceleration`.
+     - :math:`[0, \infty)`
+     - 1e-8
+   * - :code:`acceleration_relaxation`
+     - :code:`scs_float`
+     - AA relaxation factor :math:`\beta`; :code:`1.0` recovers vanilla AA. See :ref:`acceleration`.
+     - :math:`[0, 2]`
+     - 1.0
    * - :code:`write_data_filename`
      - :code:`char *`
      - If this is set the problem data is dumped to this filename.

--- a/include/glbopts.h
+++ b/include/glbopts.h
@@ -219,9 +219,14 @@ static inline void *scs_calloc(size_t count, size_t size) {
 #define TAU_FACTOR (10.)
 
 /* --- Anderson Acceleration (AA) parameters --- */
+/* Default AA type: 1 = type-I (better empirical performance, default),
+ * 0 = type-II (more numerically stable but typically slower). */
+#define ACCELERATION_TYPE_1 (1)
+/* Default Tikhonov regularization for the AA least-squares solve. Tuned
+ * for type-I; type-II tolerates much smaller (e.g. 1e-12). Users picking
+ * type-II will typically lower this. */
+#define AA_REGULARIZATION (1e-8)
 #define AA_RELAXATION (1.0)
-#define AA_REGULARIZATION_TYPE_1 (1e-8)
-#define AA_REGULARIZATION_TYPE_2 (1e-12)
 /* Reject AA steps when the output norm exceeds this multiple of the input
  * norm. 1.0 means the AA step must not increase the iterate norm. */
 #define AA_SAFEGUARD_FACTOR (1.)

--- a/include/scs.h
+++ b/include/scs.h
@@ -83,10 +83,17 @@ typedef struct {
   scs_int verbose;
   /** Whether to use warm start (put initial guess in ScsSolution struct). */
   scs_int warm_start;
-  /** Memory for acceleration. */
+  /** Memory for acceleration. Set to 0 to disable AA. Must be nonnegative. */
   scs_int acceleration_lookback;
   /** Interval to apply acceleration. */
   scs_int acceleration_interval;
+  /** Whether AA uses type-I (1) or type-II (0). */
+  scs_int acceleration_type_1;
+  /** Tikhonov regularization for the AA least-squares solve.
+   *  See `aa_init` in include/aa.h for the sign-encoded modes. */
+  scs_float acceleration_regularization;
+  /** AA relaxation factor in [0, 2]. 1.0 recovers vanilla AA. */
+  scs_float acceleration_relaxation;
   /** String, if set will dump raw prob data to this file. */
   const char *write_data_filename;
   /** String, if set will log data to this csv file (makes SCS very slow). */

--- a/src/rw.c
+++ b/src/rw.c
@@ -148,6 +148,9 @@ static void write_scs_stgs(const ScsSettings *s, FILE *fout) {
   fwrite(&warm_start, sizeof(scs_int), 1, fout);
   fwrite(&(s->acceleration_lookback), sizeof(scs_int), 1, fout);
   fwrite(&(s->acceleration_interval), sizeof(scs_int), 1, fout);
+  fwrite(&(s->acceleration_type_1), sizeof(scs_int), 1, fout);
+  fwrite(&(s->acceleration_regularization), sizeof(scs_float), 1, fout);
+  fwrite(&(s->acceleration_relaxation), sizeof(scs_float), 1, fout);
   fwrite(&(s->adaptive_scale), sizeof(scs_int), 1, fout);
   /* Do not write the write_data_filename */
   /* Do not write the log_csv_filename */
@@ -169,6 +172,9 @@ static ScsSettings *read_scs_stgs(FILE *fin, size_t file_int_sz) {
   read_int(&(s->warm_start), file_int_sz, 1, fin);
   read_int(&(s->acceleration_lookback), file_int_sz, 1, fin);
   read_int(&(s->acceleration_interval), file_int_sz, 1, fin);
+  read_int(&(s->acceleration_type_1), file_int_sz, 1, fin);
+  checked_fread(&(s->acceleration_regularization), sizeof(scs_float), 1, fin);
+  checked_fread(&(s->acceleration_relaxation), sizeof(scs_float), 1, fin);
   read_int(&(s->adaptive_scale), file_int_sz, 1, fin);
   return s;
 }

--- a/src/scs.c
+++ b/src/scs.c
@@ -408,6 +408,23 @@ static scs_int validate(const ScsData *d, const ScsCone *k,
     scs_printf("acceleration_interval must be positive (10 works well).\n");
     return -1;
   }
+  if (stgs->acceleration_lookback < 0) {
+    scs_printf("acceleration_lookback must be nonnegative "
+               "(use acceleration_type_1=0 for type-II AA).\n");
+    return -1;
+  }
+  if (!isfinite(stgs->acceleration_regularization) ||
+      stgs->acceleration_regularization < 0) {
+    scs_printf("acceleration_regularization must be a nonnegative finite "
+               "number.\n");
+    return -1;
+  }
+  if (!isfinite(stgs->acceleration_relaxation) ||
+      stgs->acceleration_relaxation < 0 ||
+      stgs->acceleration_relaxation > 2) {
+    scs_printf("acceleration_relaxation must be in [0, 2].\n");
+    return -1;
+  }
   return 0;
 }
 #endif
@@ -1026,16 +1043,14 @@ static ScsWork *init_work(const ScsData *d, const ScsCone *k,
     return SCS_NULL;
   }
   if (w->stgs->acceleration_lookback) {
-    /* TODO(HACK!) negative acceleration_lookback interpreted as type-II */
     /* min_len = mem preserves the previous FILL_MEMORY_BEFORE_SOLVE
        gate — AA holds off until the sliding window is full. */
-    if (!(w->accel = aa_init(l, IABS(w->stgs->acceleration_lookback),
-                             IABS(w->stgs->acceleration_lookback),
-                             w->stgs->acceleration_lookback > 0,
-                             w->stgs->acceleration_lookback > 0
-                                 ? AA_REGULARIZATION_TYPE_1
-                                 : AA_REGULARIZATION_TYPE_2,
-                             AA_RELAXATION, AA_SAFEGUARD_FACTOR,
+    if (!(w->accel = aa_init(l, w->stgs->acceleration_lookback,
+                             w->stgs->acceleration_lookback,
+                             w->stgs->acceleration_type_1,
+                             w->stgs->acceleration_regularization,
+                             w->stgs->acceleration_relaxation,
+                             AA_SAFEGUARD_FACTOR,
                              AA_MAX_WEIGHT_NORM, AA_IR_MAX_STEPS,
                              VERBOSITY))) {
       if (w->stgs->verbose) {

--- a/src/util.c
+++ b/src/util.c
@@ -169,6 +169,9 @@ void scs_set_default_settings(ScsSettings *stgs) {
   stgs->warm_start = WARM_START;
   stgs->acceleration_lookback = ACCELERATION_LOOKBACK;
   stgs->acceleration_interval = ACCELERATION_INTERVAL;
+  stgs->acceleration_type_1 = ACCELERATION_TYPE_1;
+  stgs->acceleration_regularization = AA_REGULARIZATION;
+  stgs->acceleration_relaxation = AA_RELAXATION;
   stgs->adaptive_scale = ADAPTIVE_SCALE;
   stgs->write_data_filename = WRITE_DATA_FILENAME;
   stgs->log_csv_filename = LOG_CSV_FILENAME;

--- a/test/problems/qafiro_tiny_qp.h
+++ b/test/problems/qafiro_tiny_qp.h
@@ -173,8 +173,10 @@ static const char *qafiro_tiny_qp(void) {
   stgs->warm_start = 0;
   stgs->normalize = 0;
   stgs->adaptive_scale = 0;
-  stgs->acceleration_lookback = -10;
+  stgs->acceleration_lookback = 10;
   stgs->acceleration_interval = 10;
+  stgs->acceleration_type_1 = 0;
+  stgs->acceleration_regularization = 1e-12;
   stgs->log_csv_filename = "qafiro_tiny_qp.csv";
 
   exitflag = scs(d, k, stgs, sol, &info);

--- a/test/problems/test_solver_options.h
+++ b/test/problems/test_solver_options.h
@@ -133,9 +133,9 @@ static const char *test_no_acceleration(void) {
 }
 
 /*
- * Test Type-II Anderson acceleration (acceleration_lookback < 0): the
- * negative lookback is the internal signal to use AA_REGULARIZATION_TYPE_2.
- * Verify convergence on a simple LP.
+ * Test Type-II Anderson acceleration via the explicit acceleration_type_1=0
+ * setting. Lower the regularization to type-II's preferred regime since the
+ * default is tuned for type-I. Verify convergence on a simple LP.
  */
 static const char *test_type2_acceleration(void) {
   ScsCone *k;
@@ -147,7 +147,9 @@ static const char *test_type2_acceleration(void) {
   const char *fail;
 
   _OPTS_SETUP(-2.0, 1.0);
-  stgs->acceleration_lookback = -10;
+  stgs->acceleration_lookback = 10;
+  stgs->acceleration_type_1 = 0;
+  stgs->acceleration_regularization = 1e-12;
 
   exitflag = scs(d, k, stgs, sol, &info);
 
@@ -157,6 +159,55 @@ static const char *test_type2_acceleration(void) {
 
   _OPTS_CLEANUP();
   return fail;
+}
+
+/*
+ * Test that a negative acceleration_lookback is rejected by validate().
+ * Previously this was overloaded to mean type-II AA; that hack is gone now,
+ * so the only valid signal for type-II is acceleration_type_1=0.
+ */
+static const char *test_negative_lookback_rejected(void) {
+  ScsCone *k;
+  ScsData *d;
+  ScsSettings *stgs;
+  ScsSolution *sol;
+  ScsInfo info = {0};
+  scs_int exitflag;
+
+  _OPTS_SETUP(-2.0, 1.0);
+  stgs->verbose = 0;
+  stgs->acceleration_lookback = -10;
+
+  exitflag = scs(d, k, stgs, sol, &info);
+
+  mu_assert("test_negative_lookback_rejected: expected SCS_FAILED",
+            exitflag == SCS_FAILED);
+
+  _OPTS_CLEANUP();
+  return 0;
+}
+
+/*
+ * Test that an invalid acceleration_relaxation (outside [0, 2]) is rejected.
+ */
+static const char *test_invalid_aa_relaxation_rejected(void) {
+  ScsCone *k;
+  ScsData *d;
+  ScsSettings *stgs;
+  ScsSolution *sol;
+  ScsInfo info = {0};
+  scs_int exitflag;
+
+  _OPTS_SETUP(-2.0, 1.0);
+  stgs->verbose = 0;
+  stgs->acceleration_relaxation = 2.5;
+
+  exitflag = scs(d, k, stgs, sol, &info);
+  mu_assert("test_invalid_aa_relaxation_rejected: expected SCS_FAILED",
+            exitflag == SCS_FAILED);
+
+  _OPTS_CLEANUP();
+  return 0;
 }
 
 /*

--- a/test/problems/test_solver_options.h
+++ b/test/problems/test_solver_options.h
@@ -188,6 +188,73 @@ static const char *test_negative_lookback_rejected(void) {
 }
 
 /*
+ * Test that non-default acceleration_relaxation values still solve.
+ * Sweeps three points in [0, 2]: 0.5 (under-relaxed), 1.0 (vanilla), and 1.7
+ * (over-relaxed). All three should converge on the simple LP.
+ */
+static const char *test_aa_relaxation_sweep(void) {
+  scs_float relaxations[] = {0.5, 1.0, 1.7};
+  scs_int n_relax = sizeof(relaxations) / sizeof(relaxations[0]);
+  scs_int j;
+  for (j = 0; j < n_relax; ++j) {
+    ScsCone *k;
+    ScsData *d;
+    ScsSettings *stgs;
+    ScsSolution *sol;
+    ScsInfo info = {0};
+    scs_int exitflag;
+    const char *fail;
+
+    _OPTS_SETUP(-2.0, 1.0);
+    stgs->verbose = 0;
+    stgs->acceleration_relaxation = relaxations[j];
+
+    exitflag = scs(d, k, stgs, sol, &info);
+    mu_assert("test_aa_relaxation_sweep: expected SCS_SOLVED",
+              exitflag == SCS_SOLVED);
+    fail = verify_solution_correct(d, k, stgs, &info, sol, exitflag);
+
+    _OPTS_CLEANUP();
+    if (fail) return fail;
+  }
+  return 0;
+}
+
+/*
+ * Test that non-default acceleration_regularization values still solve.
+ * Includes 0 (regularization disabled — valid per aa.h) and a value much
+ * larger than the default (should still produce a stable solve since AA
+ * just shrinks toward the un-accelerated update).
+ */
+static const char *test_aa_regularization_sweep(void) {
+  scs_float regs[] = {0.0, 1e-12, 1e-4};
+  scs_int n_regs = sizeof(regs) / sizeof(regs[0]);
+  scs_int j;
+  for (j = 0; j < n_regs; ++j) {
+    ScsCone *k;
+    ScsData *d;
+    ScsSettings *stgs;
+    ScsSolution *sol;
+    ScsInfo info = {0};
+    scs_int exitflag;
+    const char *fail;
+
+    _OPTS_SETUP(-2.0, 1.0);
+    stgs->verbose = 0;
+    stgs->acceleration_regularization = regs[j];
+
+    exitflag = scs(d, k, stgs, sol, &info);
+    mu_assert("test_aa_regularization_sweep: expected SCS_SOLVED",
+              exitflag == SCS_SOLVED);
+    fail = verify_solution_correct(d, k, stgs, &info, sol, exitflag);
+
+    _OPTS_CLEANUP();
+    if (fail) return fail;
+  }
+  return 0;
+}
+
+/*
  * Test that an invalid acceleration_relaxation (outside [0, 2]) is rejected.
  */
 static const char *test_invalid_aa_relaxation_rejected(void) {
@@ -204,6 +271,41 @@ static const char *test_invalid_aa_relaxation_rejected(void) {
 
   exitflag = scs(d, k, stgs, sol, &info);
   mu_assert("test_invalid_aa_relaxation_rejected: expected SCS_FAILED",
+            exitflag == SCS_FAILED);
+
+  _OPTS_CLEANUP();
+  return 0;
+}
+
+/*
+ * Test that NaN/negative acceleration_regularization is rejected by validate.
+ */
+static const char *test_invalid_aa_regularization_rejected(void) {
+  ScsCone *k;
+  ScsData *d;
+  ScsSettings *stgs;
+  ScsSolution *sol;
+  ScsInfo info = {0};
+  scs_int exitflag;
+
+  _OPTS_SETUP(-2.0, 1.0);
+  stgs->verbose = 0;
+  stgs->acceleration_regularization = -1e-12;
+
+  exitflag = scs(d, k, stgs, sol, &info);
+  mu_assert("test_invalid_aa_regularization_rejected: negative reg "
+            "should be SCS_FAILED",
+            exitflag == SCS_FAILED);
+
+  _OPTS_CLEANUP();
+
+  _OPTS_SETUP(-2.0, 1.0);
+  stgs->verbose = 0;
+  stgs->acceleration_regularization = NAN;
+
+  exitflag = scs(d, k, stgs, sol, &info);
+  mu_assert("test_invalid_aa_regularization_rejected: NaN reg "
+            "should be SCS_FAILED",
             exitflag == SCS_FAILED);
 
   _OPTS_CLEANUP();

--- a/test/run_tests.c
+++ b/test/run_tests.c
@@ -142,8 +142,11 @@ static const char *all_tests(void) {
   mu_run_test(test_adaptive_scale);
   mu_run_test(test_no_acceleration);
   mu_run_test(test_type2_acceleration);
+  mu_run_test(test_aa_relaxation_sweep);
+  mu_run_test(test_aa_regularization_sweep);
   mu_run_test(test_negative_lookback_rejected);
   mu_run_test(test_invalid_aa_relaxation_rejected);
+  mu_run_test(test_invalid_aa_regularization_rejected);
   mu_run_test(test_normalize_off);
   mu_run_test(test_normalize_roundtrip);
   mu_run_test(test_scs_version);

--- a/test/run_tests.c
+++ b/test/run_tests.c
@@ -142,6 +142,8 @@ static const char *all_tests(void) {
   mu_run_test(test_adaptive_scale);
   mu_run_test(test_no_acceleration);
   mu_run_test(test_type2_acceleration);
+  mu_run_test(test_negative_lookback_rejected);
+  mu_run_test(test_invalid_aa_relaxation_rejected);
   mu_run_test(test_normalize_off);
   mu_run_test(test_normalize_roundtrip);
   mu_run_test(test_scs_version);


### PR DESCRIPTION
## Summary
- Replaces the negative-\`acceleration_lookback\` hack (sign overloaded to switch type-I vs type-II) with three explicit settings: \`acceleration_type_1\`, \`acceleration_regularization\`, \`acceleration_relaxation\`.
- \`acceleration_lookback\` is now strictly nonnegative; \`validate()\` rejects negative values with a message pointing users at \`acceleration_type_1=0\`.
- Default regularization unifies the previous per-type \`AA_REGULARIZATION_TYPE_{1,2}\` macros into a single \`AA_REGULARIZATION=1e-8\` tuned for type-I; users picking type-II will typically lower it (e.g. 1e-12).
- \`rw.c\` serializes the three new fields after the existing \`acceleration_*\` settings; readers will need a matching SCS version.
- Tests updated: \`test_type2_acceleration\` sets \`acceleration_type_1=0\` explicitly; new tests for negative-lookback and out-of-range relaxation rejection.
- Docs updated (\`api/settings.rst\`, \`algorithm/acceleration.rst\`) to remove the hack reference and document the new settings.

Companion PR in scs-python: https://github.com/bodono/scs-python (forthcoming).

## Test plan
- [x] \`make test\` — all 54 \`run_tests_direct\` and \`run_tests_indirect\` tests pass locally.
- [ ] CI matrix (DLONG, SFLOAT, MKL, USE_LAPACK, USE_SPECTRAL_CONES, etc.).

🤖 Generated with [Claude Code](https://claude.com/claude-code)