### PR TITLE
Harden input validation

### DIFF
--- a/linsys/cpu/indirect/private.c
+++ b/linsys/cpu/indirect/private.c
@@ -67,12 +67,10 @@ static void set_preconditioner(ScsLinSysWork *p) {
       M[i] += A->x[k] * A->x[k] / p->diag_r[A->n + A->i[k]];
     }
     if (P) {
-      /* P is upper triangular stored CSC with rows sorted ascending within
-       * each column, so the diagonal entry (row==col) is always last.
-       * Check only the last entry: O(1) instead of O(nnz_in_col). */
-      scs_int last = P->p[i + 1] - 1;
-      if (last >= P->p[i] && P->i[last] == i) {
-        M[i] += P->x[last];
+      for (k = P->p[i]; k < P->p[i + 1]; ++k) {
+        if (P->i[k] == i) {
+          M[i] += P->x[k];
+        }
       }
     }
     /* finally invert for pre-conditioner */

--- a/linsys/scs_matrix.c
+++ b/linsys/scs_matrix.c
@@ -63,46 +63,46 @@ void SCS(free_scs_matrix)(ScsMatrix *A) {
 /* ======================== Validation ======================== */
 
 scs_int SCS(validate_lin_sys)(const ScsMatrix *A, const ScsMatrix *P) {
-  scs_int i, j, r_max, Anz;
+  scs_int i, j, Anz, Pnz;
   if (!A) {
     scs_printf("A matrix missing\n");
+    return -1;
+  }
+  if (A->m <= 0 || A->n <= 0) {
+    scs_printf("A matrix dimensions must be positive\n");
     return -1;
   }
   if (!A->x || !A->i || !A->p) {
     scs_printf("data incompletely specified\n");
     return -1;
   }
-  /* detects some errors in A col ptrs: */
-  Anz = A->p[A->n];
-  /* Disable this check which is slowish and typically just produces noise. */
-  /*
-  if (Anz > 0) {
-    for (i = 0; i < A->n; ++i) {
-      if (A->p[i] == A->p[i + 1]) {
-        scs_printf("WARN: A->p (column pointers) not strictly increasing, "
-                   "column %li empty\n",
-                   (long)i);
-      } else if (A->p[i] > A->p[i + 1]) {
-        scs_printf("ERROR: A->p (column pointers) decreasing\n");
-        return -1;
-      }
+  if (A->p[0] != 0) {
+    scs_printf("A->p[0] must equal 0\n");
+    return -1;
+  }
+  for (j = 0; j < A->n; ++j) {
+    if (A->p[j] < 0 || A->p[j] > A->p[j + 1]) {
+      scs_printf("A->p (column pointers) must be nonnegative and "
+                 "nondecreasing\n");
+      return -1;
     }
   }
-  */
+  Anz = A->p[A->n];
   if (((scs_float)Anz / A->m > A->n) || (Anz < 0)) {
     scs_printf("Anz (nonzeros in A) = %li, outside of valid range\n",
                (long)Anz);
     return -1;
   }
-  r_max = 0;
   for (i = 0; i < Anz; ++i) {
-    if (A->i[i] > r_max) {
-      r_max = A->i[i];
+    if (A->i[i] < 0 || A->i[i] >= A->m) {
+      scs_printf("A row index %li outside valid range [0, %li]\n",
+                 (long)A->i[i], (long)A->m - 1);
+      return -1;
     }
-  }
-  if (r_max > A->m - 1) {
-    scs_printf("number of rows in A inconsistent with input dimension\n");
-    return -1;
+    if (!isfinite(A->x[i])) {
+      scs_printf("A contains a non-finite entry\n");
+      return -1;
+    }
   }
   if (P) {
     if (!P->x || !P->i || !P->p) {
@@ -118,10 +118,36 @@ scs_int SCS(validate_lin_sys)(const ScsMatrix *A, const ScsMatrix *P) {
       scs_printf("P is not square\n");
       return -1;
     }
+    if (P->p[0] != 0) {
+      scs_printf("P->p[0] must equal 0\n");
+      return -1;
+    }
+    for (j = 0; j < P->n; ++j) {
+      if (P->p[j] < 0 || P->p[j] > P->p[j + 1]) {
+        scs_printf("P->p (column pointers) must be nonnegative and "
+                   "nondecreasing\n");
+        return -1;
+      }
+    }
+    Pnz = P->p[P->n];
+    if (((scs_float)Pnz / P->m > P->n) || (Pnz < 0)) {
+      scs_printf("Pnz (nonzeros in P) = %li, outside of valid range\n",
+                 (long)Pnz);
+      return -1;
+    }
     for (j = 0; j < P->n; j++) { /* cols */
       for (i = P->p[j]; i < P->p[j + 1]; i++) {
+        if (P->i[i] < 0 || P->i[i] >= P->n) {
+          scs_printf("P row index %li outside valid range [0, %li]\n",
+                     (long)P->i[i], (long)P->n - 1);
+          return -1;
+        }
         if (P->i[i] > j) { /* if row > */
           scs_printf("P is not upper triangular\n");
+          return -1;
+        }
+        if (!isfinite(P->x[i])) {
+          scs_printf("P contains a non-finite entry\n");
           return -1;
         }
       }

--- a/src/cones.c
+++ b/src/cones.c
@@ -601,6 +601,10 @@ scs_int SCS(validate_cones)(const ScsData *d, const ScsCone *k) {
       return -1;
     }
     for (i = 0; i < k->bsize - 1; ++i) {
+      if (!isfinite(k->bl[i]) || !isfinite(k->bu[i])) {
+        scs_printf("box cone bounds must be finite\n");
+        return -1;
+      }
       if (k->bl[i] > k->bu[i]) {
         scs_printf("infeasible: box lower bound larger than upper bound\n");
         return -1;
@@ -673,8 +677,8 @@ scs_int SCS(validate_cones)(const ScsData *d, const ScsCone *k) {
       return -1;
     }
     for (i = 0; i < k->psize; ++i) {
-      if (k->p[i] < -1 || k->p[i] > 1) {
-        scs_printf("power cone error, values must be in [-1,1]\n");
+      if (!isfinite(k->p[i]) || k->p[i] < -1 || k->p[i] > 1) {
+        scs_printf("power cone error, values must be finite and in [-1,1]\n");
         return -1;
       }
     }

--- a/src/cones.c
+++ b/src/cones.c
@@ -601,8 +601,12 @@ scs_int SCS(validate_cones)(const ScsData *d, const ScsCone *k) {
       return -1;
     }
     for (i = 0; i < k->bsize - 1; ++i) {
-      if (!isfinite(k->bl[i]) || !isfinite(k->bu[i])) {
-        scs_printf("box cone bounds must be finite\n");
+      if (isnan(k->bl[i]) || isnan(k->bu[i])) {
+        scs_printf("box cone bounds cannot be NaN\n");
+        return -1;
+      }
+      if (k->bl[i] == INFINITY || k->bu[i] == -INFINITY) {
+        scs_printf("box cone bounds use invalid infinity direction\n");
         return -1;
       }
       if (k->bl[i] > k->bu[i]) {

--- a/src/scs.c
+++ b/src/scs.c
@@ -368,6 +368,12 @@ static scs_int validate(const ScsData *d, const ScsCone *k,
                (long)d->m, (long)d->n);
     return -1;
   }
+  if (d->A && (d->A->m != d->m || d->A->n != d->n)) {
+    scs_printf("A dimensions = (%li, %li), inconsistent with m = %li, "
+               "n = %li\n",
+               (long)d->A->m, (long)d->A->n, (long)d->m, (long)d->n);
+    return -1;
+  }
   if (SCS(validate_lin_sys)(d->A, d->P) < 0) {
     scs_printf("invalid linear system input data\n");
     return -1;
@@ -380,28 +386,32 @@ static scs_int validate(const ScsData *d, const ScsCone *k,
     scs_printf("max_iters must be positive\n");
     return -1;
   }
-  if (stgs->eps_abs < 0) {
-    scs_printf("eps_abs tolerance must be positive\n");
+  if (!isfinite(stgs->eps_abs) || stgs->eps_abs < 0) {
+    scs_printf("eps_abs tolerance must be a nonnegative finite number\n");
     return -1;
   }
-  if (stgs->eps_rel < 0) {
-    scs_printf("eps_rel tolerance must be positive\n");
+  if (!isfinite(stgs->eps_rel) || stgs->eps_rel < 0) {
+    scs_printf("eps_rel tolerance must be a nonnegative finite number\n");
     return -1;
   }
-  if (stgs->eps_infeas < 0) {
-    scs_printf("eps_infeas tolerance must be positive\n");
+  if (!isfinite(stgs->eps_infeas) || stgs->eps_infeas < 0) {
+    scs_printf("eps_infeas tolerance must be a nonnegative finite number\n");
     return -1;
   }
-  if (stgs->alpha <= 0 || stgs->alpha >= 2) {
+  if (!isfinite(stgs->alpha) || stgs->alpha <= 0 || stgs->alpha >= 2) {
     scs_printf("alpha must be in (0,2)\n");
     return -1;
   }
-  if (stgs->rho_x <= 0) {
-    scs_printf("rho_x must be positive (1e-3 works well).\n");
+  if (!isfinite(stgs->rho_x) || stgs->rho_x <= 0) {
+    scs_printf("rho_x must be a positive finite number (1e-3 works well).\n");
     return -1;
   }
-  if (stgs->scale <= 0) {
-    scs_printf("scale must be positive (1 works well).\n");
+  if (!isfinite(stgs->scale) || stgs->scale <= 0) {
+    scs_printf("scale must be a positive finite number (1 works well).\n");
+    return -1;
+  }
+  if (!isfinite(stgs->time_limit_secs) || stgs->time_limit_secs < 0) {
+    scs_printf("time_limit_secs must be a nonnegative finite number.\n");
     return -1;
   }
   if (stgs->acceleration_interval <= 0) {

--- a/test/problems/test_validation.h
+++ b/test/problems/test_validation.h
@@ -54,6 +54,13 @@ static const char *test_validation(void) {
   mu_assert("validation: eps_abs < 0 should fail", exitflag == SCS_FAILED);
   VALIDATION_CLEANUP();
 
+  /* eps_abs NaN */
+  VALIDATION_SETUP();
+  stgs->eps_abs = NAN;
+  exitflag = scs(d, k, stgs, sol, &info);
+  mu_assert("validation: eps_abs NaN should fail", exitflag == SCS_FAILED);
+  VALIDATION_CLEANUP();
+
   /* eps_rel < 0 */
   VALIDATION_SETUP();
   stgs->eps_rel = -1;
@@ -101,6 +108,14 @@ static const char *test_validation(void) {
   stgs->scale = 0.0;
   exitflag = scs(d, k, stgs, sol, &info);
   mu_assert("validation: scale <= 0 should fail", exitflag == SCS_FAILED);
+  VALIDATION_CLEANUP();
+
+  /* time_limit_secs NaN */
+  VALIDATION_SETUP();
+  stgs->time_limit_secs = NAN;
+  exitflag = scs(d, k, stgs, sol, &info);
+  mu_assert("validation: time_limit_secs NaN should fail",
+            exitflag == SCS_FAILED);
   VALIDATION_CLEANUP();
 
   /* acceleration_interval <= 0 */
@@ -187,6 +202,37 @@ static const char *test_validation(void) {
   d->A = SCS_NULL;
   exitflag = scs(d, k, stgs, sol, &info);
   mu_assert("validation: missing A should fail", exitflag == SCS_FAILED);
+  VALIDATION_CLEANUP();
+
+  /* A dimensions inconsistent with ScsData */
+  VALIDATION_SETUP();
+  d->A->m = d->m + 1;
+  exitflag = scs(d, k, stgs, sol, &info);
+  mu_assert("validation: A dims inconsistent with data should fail",
+            exitflag == SCS_FAILED);
+  VALIDATION_CLEANUP();
+
+  /* A has negative row index */
+  VALIDATION_SETUP();
+  d->A->i[0] = -1;
+  exitflag = scs(d, k, stgs, sol, &info);
+  mu_assert("validation: A negative row index should fail",
+            exitflag == SCS_FAILED);
+  VALIDATION_CLEANUP();
+
+  /* A column pointers must be nondecreasing */
+  VALIDATION_SETUP();
+  d->A->p[0] = 1;
+  exitflag = scs(d, k, stgs, sol, &info);
+  mu_assert("validation: A invalid column pointer should fail",
+            exitflag == SCS_FAILED);
+  VALIDATION_CLEANUP();
+
+  /* A has non-finite data */
+  VALIDATION_SETUP();
+  d->A->x[0] = NAN;
+  exitflag = scs(d, k, stgs, sol, &info);
+  mu_assert("validation: A NaN entry should fail", exitflag == SCS_FAILED);
   VALIDATION_CLEANUP();
 
 #undef VALIDATION_SETUP

--- a/test/problems/test_validation.h
+++ b/test/problems/test_validation.h
@@ -1,4 +1,5 @@
 #include "glbopts.h"
+#include "cones.h"
 #include "minunit.h"
 #include "problem_utils.h"
 #include "scs.h"
@@ -160,6 +161,48 @@ static const char *test_validation(void) {
     k->bl = SCS_NULL; /* prevent double-free */
     k->bu = SCS_NULL;
     VALIDATION_CLEANUP();
+  }
+
+  /* box cone one-sided infinite bounds are valid */
+  {
+    ScsData d_box = {0};
+    ScsCone k_box = {0};
+    scs_float bl_inf[] = {-INFINITY, -1.0};
+    scs_float bu_inf[] = {1.0, INFINITY};
+    d_box.m = 3;
+    k_box.bsize = 3; /* 1 t-var + 2 bounded vars */
+    k_box.bl = bl_inf;
+    k_box.bu = bu_inf;
+    mu_assert("validation: box infinite bounds should pass",
+              SCS(validate_cones)(&d_box, &k_box) == 0);
+  }
+
+  /* box cone NaN bound */
+  {
+    ScsData d_box = {0};
+    ScsCone k_box = {0};
+    scs_float bl_nan[] = {NAN};
+    scs_float bu_nan[] = {1.0};
+    d_box.m = 2;
+    k_box.bsize = 2; /* 1 t-var + 1 bounded var */
+    k_box.bl = bl_nan;
+    k_box.bu = bu_nan;
+    mu_assert("validation: box NaN bound should fail",
+              SCS(validate_cones)(&d_box, &k_box) < 0);
+  }
+
+  /* box cone infinities must point in the valid bound direction */
+  {
+    ScsData d_box = {0};
+    ScsCone k_box = {0};
+    scs_float bl_bad_inf[] = {INFINITY};
+    scs_float bu_bad_inf[] = {INFINITY};
+    d_box.m = 2;
+    k_box.bsize = 2; /* 1 t-var + 1 bounded var */
+    k_box.bl = bl_bad_inf;
+    k_box.bu = bu_bad_inf;
+    mu_assert("validation: box +inf lower bound should fail",
+              SCS(validate_cones)(&d_box, &k_box) < 0);
   }
 
   /* power cone p out of range */


### PR DESCRIPTION
Summary:
- Validate CSC dimensions, column pointers, row indices, triangular P structure, and finite matrix values.
- Reject nonfinite solver tolerances, time limits, and cone parameters.
- Reject NaN box bounds while allowing valid one-sided infinite box bounds.
- Make the indirect preconditioner scan for diagonal P entries instead of assuming column order.

Tests:
- make clean && make test && out/run_tests_direct