### PR TITLE
Check allocations before use

### DIFF
--- a/linsys/cpu/direct/private.c
+++ b/linsys/cpu/direct/private.c
@@ -6,6 +6,9 @@
 
 static scs_int _ldl_init(ScsMatrix *A, scs_int *P, scs_float **info) {
   *info = (scs_float *)scs_calloc(AMD_INFO, sizeof(scs_float));
+  if (!*info) {
+    return -1;
+  }
   return amd_order(A->n, A->p, A->i, P, (scs_float *)SCS_NULL, *info);
 }
 
@@ -17,6 +20,9 @@ static scs_int ldl_prepare(ScsLinSysWork *p) {
   p->Lnz = (scs_int *)scs_calloc(n, sizeof(scs_int));
   p->iwork = (scs_int *)scs_calloc(3 * n, sizeof(scs_int));
   L->p = (scs_int *)scs_calloc((1 + n), sizeof(scs_int));
+  if (!p->etree || !p->Lnz || !p->iwork || !L->p) {
+    return -1;
+  }
   nzmax = QDLDL_etree(n, kkt->p, kkt->i, p->iwork, p->Lnz, p->etree);
   if (nzmax < 0) {
     scs_printf("Error in elimination tree calculation.\n");
@@ -34,6 +40,9 @@ static scs_int ldl_prepare(ScsLinSysWork *p) {
   p->D = (scs_float *)scs_calloc(n, sizeof(scs_float));
   p->bwork = (QDLDL_bool *)scs_calloc(n, sizeof(QDLDL_bool));
   p->fwork = (scs_float *)scs_calloc(n, sizeof(scs_float));
+  if (!L->x || !L->i || !p->Dinv || !p->D || !p->bwork || !p->fwork) {
+    return -1;
+  }
   return nzmax;
 }
 
@@ -174,13 +183,20 @@ static ScsMatrix *permute_kkt(const ScsMatrix *A, const ScsMatrix *P,
 #endif
   Pinv = cs_pinv(p->perm, A->n + A->m);
   idx_mapping = (scs_int *)scs_calloc(kkt_nnz, sizeof(scs_int));
-  if (!idx_mapping) {
+  if (!Pinv || !idx_mapping) {
     SCS(cs_spfree)(kkt);
     scs_free(Pinv);
     scs_free(info);
     return SCS_NULL;
   }
   kkt_perm = cs_symperm(kkt, Pinv, idx_mapping, 1);
+  if (!kkt_perm) {
+    SCS(cs_spfree)(kkt);
+    scs_free(Pinv);
+    scs_free(info);
+    scs_free(idx_mapping);
+    return SCS_NULL;
+  }
   for (i = 0; i < A->n + A->m; i++) {
     p->diag_r_idxs[i] = idx_mapping[p->diag_r_idxs[i]];
   }
@@ -207,16 +223,25 @@ ScsLinSysWork *scs_init_lin_sys_work(const ScsMatrix *A, const ScsMatrix *P,
   p->m = A->m;
   p->n = A->n;
   p->diag_p = (scs_float *)scs_calloc(A->n, sizeof(scs_float));
-  p->perm = (scs_int *)scs_calloc(sizeof(scs_int), n_plus_m);
+  p->perm = (scs_int *)scs_calloc(n_plus_m, sizeof(scs_int));
   p->L = (ScsMatrix *)scs_calloc(1, sizeof(ScsMatrix));
   p->bp = (scs_float *)scs_calloc(n_plus_m, sizeof(scs_float));
   p->diag_r_idxs = (scs_int *)scs_calloc(n_plus_m, sizeof(scs_int));
   p->factorizations = 0;
+  if (!p->diag_p || !p->perm || !p->L || !p->bp || !p->diag_r_idxs) {
+    scs_free_lin_sys_work(p);
+    return SCS_NULL;
+  }
   p->L->m = n_plus_m;
   p->L->n = n_plus_m;
   p->kkt = permute_kkt(A, P, p, diag_r);
+  if (!p->kkt) {
+    scs_free_lin_sys_work(p);
+    return SCS_NULL;
+  }
   ldl_prepare_status = ldl_prepare(p);
-  ldl_status = ldl_factor(p, A->n);
+  ldl_status =
+      ldl_prepare_status < 0 ? ldl_prepare_status : ldl_factor(p, A->n);
   if (ldl_prepare_status < 0 || ldl_status < 0) {
     scs_printf("Error in LDL initial factorization.\n");
     scs_free_lin_sys_work(p);

--- a/linsys/cpu/indirect/private.c
+++ b/linsys/cpu/indirect/private.c
@@ -227,6 +227,9 @@ const char *scs_get_lin_sys_method(void) {
 ScsLinSysWork *scs_init_lin_sys_work(const ScsMatrix *A, const ScsMatrix *P,
                                      const scs_float *diag_r) {
   ScsLinSysWork *p = (ScsLinSysWork *)scs_calloc(1, sizeof(ScsLinSysWork));
+  if (!p) {
+    return SCS_NULL;
+  }
   p->A = A;
   p->P = P;
   p->m = A->m;
@@ -239,25 +242,32 @@ ScsLinSysWork *scs_init_lin_sys_work(const ScsMatrix *A, const ScsMatrix *P,
 
   /* memory for A transpose */
   p->At = (ScsMatrix *)scs_calloc(1, sizeof(ScsMatrix));
+  if (!p->p || !p->r || !p->Gp || !p->tmp || !p->At) {
+    scs_free_lin_sys_work(p);
+    return SCS_NULL;
+  }
   p->At->m = A->n;
   p->At->n = A->m;
   p->At->i = (scs_int *)scs_calloc((A->p[A->n]), sizeof(scs_int));
   p->At->p = (scs_int *)scs_calloc((A->m + 1), sizeof(scs_int));
   p->At->x = (scs_float *)scs_calloc((A->p[A->n]), sizeof(scs_float));
+  if (!p->At->i || !p->At->p || !p->At->x) {
+    scs_free_lin_sys_work(p);
+    return SCS_NULL;
+  }
   transpose(A, p);
 
   /* preconditioner memory */
   p->diag_r = diag_r;
   p->z = (scs_float *)scs_calloc(A->n, sizeof(scs_float));
   p->M = (scs_float *)scs_calloc(A->n, sizeof(scs_float));
-  set_preconditioner(p);
-
-  p->tot_cg_its = 0;
-  if (!p->p || !p->r || !p->Gp || !p->tmp || !p->At || !p->At->i || !p->At->p ||
-      !p->At->x) {
+  if (!p->z || !p->M) {
     scs_free_lin_sys_work(p);
     return SCS_NULL;
   }
+  set_preconditioner(p);
+
+  p->tot_cg_its = 0;
   return p;
 }
 

--- a/src/scs.c
+++ b/src/scs.c
@@ -297,6 +297,11 @@ static ScsResiduals *init_residuals(const ScsData *d) {
   r->px = (scs_float *)scs_calloc(d->n, sizeof(scs_float));
   r->aty = (scs_float *)scs_calloc(d->n, sizeof(scs_float));
   r->px_aty_ctau = (scs_float *)scs_calloc(d->n, sizeof(scs_float));
+  if (!r->ax || !r->ax_s || !r->ax_s_btau || !r->px || !r->aty ||
+      !r->px_aty_ctau) {
+    free_residuals(r);
+    return SCS_NULL;
+  }
   return r;
 }
 
@@ -332,17 +337,23 @@ static void populate_on_failure(scs_int m, scs_int n, ScsSolution *sol,
       if (!sol->x) {
         sol->x = (scs_float *)scs_calloc(n, sizeof(scs_float));
       }
-      SCS(scale_array)(sol->x, NAN, n);
+      if (sol->x) {
+        SCS(scale_array)(sol->x, NAN, n);
+      }
     }
     if (m > 0) {
       if (!sol->y) {
         sol->y = (scs_float *)scs_calloc(m, sizeof(scs_float));
       }
-      SCS(scale_array)(sol->y, NAN, m);
+      if (sol->y) {
+        SCS(scale_array)(sol->y, NAN, m);
+      }
       if (!sol->s) {
         sol->s = (scs_float *)scs_calloc(m, sizeof(scs_float));
       }
-      SCS(scale_array)(sol->s, NAN, m);
+      if (sol->s) {
+        SCS(scale_array)(sol->s, NAN, m);
+      }
     }
   }
 }
@@ -987,6 +998,11 @@ static ScsWork *init_work(const ScsData *d, const ScsCone *k,
   w->diag_r = (scs_float *)scs_calloc(l, sizeof(scs_float));
   /* x,y,s struct */
   w->xys_orig = (ScsSolution *)scs_calloc(1, sizeof(ScsSolution));
+  if (!w->xys_orig) {
+    scs_printf("ERROR: work memory allocation failure\n");
+    scs_finish(w);
+    return SCS_NULL;
+  }
   w->xys_orig->x = (scs_float *)scs_calloc(w->d->n, sizeof(scs_float));
   w->xys_orig->s = (scs_float *)scs_calloc(w->d->m, sizeof(scs_float));
   w->xys_orig->y = (scs_float *)scs_calloc(w->d->m, sizeof(scs_float));
@@ -1012,6 +1028,11 @@ static ScsWork *init_work(const ScsData *d, const ScsCone *k,
 
   if (w->stgs->normalize) {
     w->xys_normalized = (ScsSolution *)scs_calloc(1, sizeof(ScsSolution));
+    if (!w->xys_normalized) {
+      scs_printf("ERROR: normalized work memory allocation failure\n");
+      scs_finish(w);
+      return SCS_NULL;
+    }
     w->xys_normalized->x = (scs_float *)scs_calloc(w->d->n, sizeof(scs_float));
     w->xys_normalized->s = (scs_float *)scs_calloc(w->d->m, sizeof(scs_float));
     w->xys_normalized->y = (scs_float *)scs_calloc(w->d->m, sizeof(scs_float));


### PR DESCRIPTION
Summary:
- Check indirect linear-system allocations before transpose, preconditioner setup, and later use.
- Check direct LDL and permutation allocations before dereference or factorization.
- Harden solver workspace failure paths that previously dereferenced partially allocated solution/residual storage.

Tests:
- make clean && make test && out/run_tests_direct && out/run_tests_indirect