### PR TITLE
Keep CSV log file open per solve

### DIFF
--- a/include/rw.h
+++ b/include/rw.h
@@ -18,8 +18,9 @@ void SCS(write_data)(const ScsData *d, const ScsCone *k,
                      const ScsSettings *stgs);
 scs_int SCS(read_data)(const char *filename, ScsData **d, ScsCone **k,
                        ScsSettings **stgs);
-void SCS(log_data_to_csv)(const ScsCone *k, const ScsSettings *stgs,
-                          const ScsWork *w, scs_int iter,
+scs_int SCS(open_csv_log_file)(ScsWork *w);
+void SCS(close_csv_log_file)(ScsWork *w);
+void SCS(log_data_to_csv)(const ScsCone *k, const ScsWork *w, scs_int iter,
                           SCS(timer) * solve_timer);
 
 #ifdef __cplusplus

--- a/include/scs_work.h
+++ b/include/scs_work.h
@@ -12,6 +12,8 @@
 #ifndef SCS_WORK_H_GUARD
 #define SCS_WORK_H_GUARD
 
+#include <stdio.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -67,6 +69,7 @@ struct SCS_WORK {
   ScsData *d;                     /* Problem data deep copy NORMALIZED */
   ScsCone *k;                     /* Problem cone deep copy */
   ScsSettings *stgs;      /* contains solver settings specified by user */
+  FILE *log_csv_fout;     /* open CSV log stream for current solve */
   ScsLinSysWork *p;       /* struct populated by linear system solver */
   ScsScaling *scal;       /* contains the re-scaling data */
   ScsConeWork *cone_work; /* workspace for the cone projection step */

--- a/src/rw.c
+++ b/src/rw.c
@@ -28,8 +28,13 @@ scs_int SCS(read_data)(const char *filename, ScsData **d, ScsCone **k,
   /* Failure */
   return -1;
 }
-void SCS(log_data_to_csv)(const ScsCone *k, const ScsSettings *stgs,
-                          const ScsWork *w, scs_int iter,
+scs_int SCS(open_csv_log_file)(ScsWork *w) {
+  return 0;
+}
+void SCS(close_csv_log_file)(ScsWork *w) {
+  /* Do nothing */
+}
+void SCS(log_data_to_csv)(const ScsCone *k, const ScsWork *w, scs_int iter,
                           SCS(timer) * solve_timer) {
   /* Do nothing */
 }
@@ -314,18 +319,35 @@ scs_int SCS(read_data)(const char *filename, ScsData **d, ScsCone **k,
   return 0;
 }
 
-void SCS(log_data_to_csv)(const ScsCone *k, const ScsSettings *stgs,
-                          const ScsWork *w, scs_int iter,
+scs_int SCS(open_csv_log_file)(ScsWork *w) {
+  if (!w || !w->stgs || !w->stgs->log_csv_filename) {
+    return 0;
+  }
+  SCS(close_csv_log_file)(w);
+  w->log_csv_fout = fopen(w->stgs->log_csv_filename, "w");
+  if (!w->log_csv_fout) {
+    scs_printf("Error: Could not open %s for writing\n",
+               w->stgs->log_csv_filename);
+    return -1;
+  }
+  return 0;
+}
+
+void SCS(close_csv_log_file)(ScsWork *w) {
+  if (w && w->log_csv_fout) {
+    fclose(w->log_csv_fout);
+    w->log_csv_fout = SCS_NULL;
+  }
+}
+
+void SCS(log_data_to_csv)(const ScsCone *k, const ScsWork *w, scs_int iter,
                           SCS(timer) * solve_timer) {
   ScsResiduals *r = w->r_orig;
   ScsResiduals *r_n = w->r_normalized;
   ScsSolution *sol = w->xys_orig;
   ScsSolution *sol_n = w->xys_normalized;
-  /* if iter 0 open to write, else open to append */
-  FILE *fout = fopen(stgs->log_csv_filename, iter == 0 ? "w" : "a");
+  FILE *fout = w->log_csv_fout;
   if (!fout) {
-    scs_printf("Error: Could not open %s for writing\n",
-               stgs->log_csv_filename);
     return;
   }
   scs_int l = w->d->m + w->d->n + 1;
@@ -472,7 +494,6 @@ void SCS(log_data_to_csv)(const ScsCone *k, const ScsSettings *stgs,
   fprintf(fout, "%.16e,", w->cone_work->newton_stats.residuals[2]);
 #endif
   fprintf(fout, "\n");
-  fclose(fout);
 }
 
 #endif

--- a/src/scs.c
+++ b/src/scs.c
@@ -351,6 +351,7 @@ static scs_int failure(ScsWork *w, scs_int m, scs_int n, ScsSolution *sol,
                        ScsInfo *info, scs_int stint, const char *msg,
                        const char *ststr) {
   scs_int status = stint;
+  SCS(close_csv_log_file)(w);
   populate_on_failure(m, n, sol, info, status, ststr);
   set_info_aa_stats(info, w ? w->accel : SCS_NULL);
   scs_printf("Failure:%s\n", msg);
@@ -1294,6 +1295,7 @@ scs_int scs_solve(ScsWork *w, ScsSolution *sol, ScsInfo *info,
   strcpy(info->lin_sys_solver, scs_get_lin_sys_method());
   info->status_val = SCS_UNFINISHED; /* not yet converged */
   update_work(w, sol);
+  SCS(open_csv_log_file)(w);
 
   if (w->stgs->verbose) {
     print_header(w, k);
@@ -1394,17 +1396,17 @@ scs_int scs_solve(ScsWork *w, ScsSolution *sol, ScsInfo *info,
     }
 
     /* Log *after* updating scale so residual recalc does not affect alg */
-    if (w->stgs->log_csv_filename) {
+    if (w->log_csv_fout) {
       /* calc residuals every iter if logging to csv */
       populate_residual_struct(w, i);
-      SCS(log_data_to_csv)(k, stgs, w, i, &solve_timer);
+      SCS(log_data_to_csv)(k, w, i, &solve_timer);
     }
   }
 
   /* Final logging after full run */
-  if (w->stgs->log_csv_filename) {
+  if (w->log_csv_fout) {
     populate_residual_struct(w, i);
-    SCS(log_data_to_csv)(k, stgs, w, i, &solve_timer);
+    SCS(log_data_to_csv)(k, w, i, &solve_timer);
   }
 
   if (w->stgs->verbose) {
@@ -1425,12 +1427,14 @@ scs_int scs_solve(ScsWork *w, ScsSolution *sol, ScsInfo *info,
     print_footer(info);
   }
 
+  SCS(close_csv_log_file)(w);
   scs_end_interrupt_listener();
   return info->status_val;
 }
 
 void scs_finish(ScsWork *w) {
   if (w) {
+    SCS(close_csv_log_file)(w);
     if (w->cone_work) {
       SCS(finish_cone)(w->cone_work);
     }


### PR DESCRIPTION
Summary:
- Open the CSV log once per scs_solve call instead of reopening on every logged iteration.
- Preserve overwrite-per-solve behavior and close the stream on normal exits, failures, and scs_finish.
- Skip per-iteration residual/log work when the log file cannot be opened.

Tests:
- make clean && make test && out/run_tests_direct