### PR TITLE
Fix PyPI downloads badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 [![Build Status](https://github.com/cvxgrp/scs/actions/workflows/build.yml/badge.svg)](https://github.com/cvxgrp/scs/actions/workflows/build.yml)
 [![Documentation](https://img.shields.io/badge/docs-online-brightgreen?logo=read-the-docs&style=flat)](https://www.cvxgrp.org/scs/)
-[![PyPI Downloads](https://img.shields.io/pypi/dm/scs.svg?label=PyPI%20downloads&cacheSeconds=86400)](https://pypistats.org/packages/scs)
+[![PyPI Downloads](https://api.pepy.tech/personalized-badge/scs?period=month&units=international_system&left_color=grey&right_color=blue&left_text=PyPI%20downloads)](https://pepy.tech/projects/scs)
 [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/scs.svg?label=Conda%20downloads)](https://anaconda.org/conda-forge/scs)
 
 SCS (`splitting conic solver`) is a numerical optimization package for solving


### PR DESCRIPTION
## Summary
- replace the Shields PyPI downloads badge with Pepy's public SVG badge endpoint
- keep the badge showing monthly PyPI downloads and link it to the Pepy project page

## Verification
- `curl -fsSI "https://api.pepy.tech/personalized-badge/scs?period=month&units=international_system&left_color=grey&right_color=blue&left_text=PyPI%20downloads"` returns `HTTP/2 200` with `content-type: image/svg+xml`