### PR TITLE
cudss: support 0.8.0+ API (offsetType + cudssDataType_t)

### DIFF
--- a/linsys/cudss/direct/private.c
+++ b/linsys/cudss/direct/private.c
@@ -151,11 +151,23 @@ ScsLinSysWork *scs_init_lin_sys_work(const ScsMatrix *A, const ScsMatrix *P,
   cudssMatrixType_t mtype = CUDSS_MTYPE_SYMMETRIC;
   cudssMatrixViewType_t mview = CUDSS_MVIEW_LOWER;
   cudssIndexBase_t base = CUDSS_BASE_ZERO;
+  /* cuDSS 0.8.0+ added an offsetType parameter before indexType. The two
+   * arrays use the same scs_int type for us, so we pass SCS_CUDA_INDEX
+   * twice. */
+#if SCS_CUDSS_NEW_API
+  CUDSS_CHECK_ABORT(cudssMatrixCreateCsr(
+                        &p->d_kkt_mat, p->kkt->m, p->kkt->n, nnz,
+                        p->d_kkt_row_ptr, NULL, p->d_kkt_col_ind, p->d_kkt_val,
+                        SCS_CUDA_INDEX, SCS_CUDA_INDEX, SCS_CUDA_FLOAT,
+                        mtype, mview, base),
+                    p, "cudssMatrixCreateCsr");
+#else
   CUDSS_CHECK_ABORT(cudssMatrixCreateCsr(
                         &p->d_kkt_mat, p->kkt->m, p->kkt->n, nnz,
                         p->d_kkt_row_ptr, NULL, p->d_kkt_col_ind, p->d_kkt_val,
                         SCS_CUDA_INDEX, SCS_CUDA_FLOAT, mtype, mview, base),
                     p, "cudssMatrixCreateCsr");
+#endif
 
   /* Allocate device memory for vectors */
   CUDA_CHECK_ABORT(

--- a/linsys/cudss/direct/private.h
+++ b/linsys/cudss/direct/private.h
@@ -5,22 +5,47 @@
 extern "C" {
 #endif
 
+#include "csparse.h"
+#include "linsys.h"
+#include <cuda_runtime.h>
+#include <cudss.h>
+
+/* cuDSS 0.8.0 renamed cudaDataType_t to cudssDataType_t (so CUDA_R_* enum
+ * values become CUDSS_R_*) and added an offsetType parameter to
+ * cudssMatrixCreateCsr. Detect via CUDSS_VER_MAJOR / CUDSS_VER_MINOR
+ * (defined in <cudss.h>) and pick the right type tokens here so the call
+ * sites stay readable. */
+#if defined(CUDSS_VER_MAJOR) &&                                                \
+    ((CUDSS_VER_MAJOR > 0) ||                                                  \
+     (CUDSS_VER_MAJOR == 0 && CUDSS_VER_MINOR >= 8))
+#define SCS_CUDSS_NEW_API 1
+#else
+#define SCS_CUDSS_NEW_API 0
+#endif
+
+#if SCS_CUDSS_NEW_API
+#ifndef SFLOAT
+#define SCS_CUDA_FLOAT CUDSS_R_64F
+#else
+#define SCS_CUDA_FLOAT CUDSS_R_32F
+#endif
+#ifndef DLONG
+#define SCS_CUDA_INDEX CUDSS_R_32I
+#else
+#define SCS_CUDA_INDEX CUDSS_R_64I
+#endif
+#else
 #ifndef SFLOAT
 #define SCS_CUDA_FLOAT CUDA_R_64F
 #else
 #define SCS_CUDA_FLOAT CUDA_R_32F
 #endif
-
 #ifndef DLONG
 #define SCS_CUDA_INDEX CUDA_R_32I
 #else
 #define SCS_CUDA_INDEX CUDA_R_64I
 #endif
-
-#include "csparse.h"
-#include "linsys.h"
-#include <cuda_runtime.h>
-#include <cudss.h>
+#endif
 
 struct SCS_LIN_SYS_WORK {
   /* General problem dimensions */

--- a/linsys/cudss/direct/private.h
+++ b/linsys/cudss/direct/private.h
@@ -12,12 +12,10 @@ extern "C" {
 
 /* cuDSS 0.8.0 renamed cudaDataType_t to cudssDataType_t (so CUDA_R_* enum
  * values become CUDSS_R_*) and added an offsetType parameter to
- * cudssMatrixCreateCsr. Detect via CUDSS_VER_MAJOR / CUDSS_VER_MINOR
- * (defined in <cudss.h>) and pick the right type tokens here so the call
- * sites stay readable. */
-#if defined(CUDSS_VER_MAJOR) &&                                                \
-    ((CUDSS_VER_MAJOR > 0) ||                                                  \
-     (CUDSS_VER_MAJOR == 0 && CUDSS_VER_MINOR >= 8))
+ * cudssMatrixCreateCsr. cudss.h exposes CUDSS_VERSION = MAJOR*10000 +
+ * MINOR*100 + PATCH; gate on that so the same source still builds against
+ * older cuDSS (<=0.7.x). */
+#if defined(CUDSS_VERSION) && CUDSS_VERSION >= 800
 #define SCS_CUDSS_NEW_API 1
 #else
 #define SCS_CUDSS_NEW_API 0


### PR DESCRIPTION
## Summary

The \`Build and Test cudss\` and \`GPU\` CI jobs started failing on master once the runner image picked up cuDSS 0.8.x. The new release made two breaking changes to the matrix-creation API:

- \`cudssMatrixCreateCsr\` gained a new \`offsetType\` parameter immediately before \`indexType\` — 14 args now instead of 13.
- All matrix-creation functions take \`cudssDataType_t\` instead of \`cudaDataType_t\`, so \`CUDA_R_64F\` / \`CUDA_R_32I\` / etc. must be replaced with \`CUDSS_R_64F\` / \`CUDSS_R_32I\` / etc.

(Migration notes: https://docs.nvidia.com/cuda/cudss/migration_guide.html)

This PR wraps both changes in a \`#if SCS_CUDSS_NEW_API\` guard driven by \`CUDSS_VER_MAJOR\` / \`CUDSS_VER_MINOR\` (both defined in \`cudss.h\`), so the same source still builds against older cuDSS (≤ 0.7.x).

\`SCS_CUDA_FLOAT\` / \`SCS_CUDA_INDEX\` already abstracted the type tokens — they now resolve to the right enum based on the detected cuDSS version. The CSR create call is the one place that needs a structurally different argument list, so that is the only call site with a \`#if/#else\`. The Dn calls only take one data-type arg in both APIs, so the existing macro substitution suffices.

## Test plan

- [ ] CI: \`Build and Test cudss\` (linux) goes green
- [ ] CI: \`GPU\` (linux) goes green
- [ ] CI: all other jobs stay green