### PR TITLE
[codex] Update GitHub Actions pins

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,7 @@ jobs:
         lapack: [0, 1]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - run: sudo apt-get update && sudo apt-get install -y libopenblas-dev liblapack-dev
       - run: make DLONG=${{ matrix.long }} USE_LAPACK=${{ matrix.lapack }}
       - run: make test DLONG=${{ matrix.long }} USE_LAPACK=${{ matrix.lapack }}
@@ -37,7 +37,7 @@ jobs:
       run:
         shell: msys2 {0}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - name: Set up MSYS2 (UCRT64) + toolchain + BLAS/LAPACK
         uses: msys2/setup-msys2@v2
@@ -85,7 +85,7 @@ jobs:
         lapack: [0, 1]
     runs-on: macos-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - run: brew update && brew install openblas lapack
       - run: make DLONG=${{ matrix.long }} USE_LAPACK=${{ matrix.lapack }}
       - run: make test DLONG=${{ matrix.long }} USE_LAPACK=${{ matrix.lapack }}

--- a/.github/workflows/build_mkl.yml
+++ b/.github/workflows/build_mkl.yml
@@ -46,7 +46,7 @@ jobs:
         echo "LD_LIBRARY_PATH=$ONEAPI/mkl/latest/lib/intel64:$ONEAPI/compiler/latest/lib:$LD_LIBRARY_PATH" >> $GITHUB_ENV
 
     - name: checkout project code
-      uses: actions/checkout@v6
+      uses: actions/checkout@v7
 
     - name: Build SCS MKL and test
       run: |

--- a/.github/workflows/build_openmp.yml
+++ b/.github/workflows/build_openmp.yml
@@ -17,7 +17,7 @@ jobs:
 
     steps:
     - name: checkout project code
-      uses: actions/checkout@v6
+      uses: actions/checkout@v7
 
     - name: install deps
       run: sudo apt-get install libopenblas-dev liblapack-dev

--- a/.github/workflows/build_spectral.yml
+++ b/.github/workflows/build_spectral.yml
@@ -17,7 +17,7 @@ jobs:
 
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - run: sudo apt-get update && sudo apt-get install -y libopenblas-dev liblapack-dev
       - run: make DLONG=${{ matrix.long }} USE_LAPACK=1 USE_SPECTRAL_CONES=${{ matrix.spectral }}
       - run: make test DLONG=${{ matrix.long }} USE_LAPACK=1 USE_SPECTRAL_CONES=${{ matrix.spectral }}
@@ -34,7 +34,7 @@ jobs:
 
     runs-on: macos-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - run: brew update && brew install openblas lapack
       - run: export CC="clang -fsanitize=address -fsanitize=undefined -fsanitize=float-divide-by-zero -fsanitize=float-cast-overflow"
       - run: make DLONG=${{ matrix.long }} USE_LAPACK=1 USE_SPECTRAL_CONES=${{ matrix.spectral }}

--- a/.github/workflows/buildpp.yml
+++ b/.github/workflows/buildpp.yml
@@ -12,7 +12,7 @@ jobs:
   linux:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - run: |
           sudo apt-get install libopenblas-dev liblapack-dev
           export CC=g++
@@ -25,7 +25,7 @@ jobs:
 
   #  runs-on: windows-latest
   #  steps:
-  #    - uses: actions/checkout@v6
+  #    - uses: actions/checkout@v7
   #    - run: choco install clapack
   #    - run: make
   #    - run: make test
@@ -34,7 +34,7 @@ jobs:
   mac:
     runs-on: macos-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - run: |
           brew install openblas lapack
           export CC=clang++

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -12,7 +12,7 @@ jobs:
   linux:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - run: |
           sudo apt-get install libopenblas-dev liblapack-dev
           mkdir out
@@ -31,7 +31,7 @@ jobs:
   mac:
     runs-on: macos-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - run: |
           brew install openblas lapack
           mkdir out

--- a/.github/workflows/cmake_cudss.yml
+++ b/.github/workflows/cmake_cudss.yml
@@ -16,8 +16,8 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v6
-      - uses: Jimver/cuda-toolkit@v0.2.30
+      - uses: actions/checkout@v7
+      - uses: Jimver/cuda-toolkit@v0.2.35
         id: cuda-toolkit
         with:
           method: network

--- a/.github/workflows/cmake_mkl.yml
+++ b/.github/workflows/cmake_mkl.yml
@@ -47,7 +47,7 @@ jobs:
         echo "LD_LIBRARY_PATH=$ONEAPI/mkl/latest/lib/intel64:$ONEAPI/compiler/latest/lib:$LD_LIBRARY_PATH" >> $GITHUB_ENV
 
     - name: checkout project code
-      uses: actions/checkout@v6
+      uses: actions/checkout@v7
 
     - name: Build SCS MKL and test
       run: |

--- a/.github/workflows/cmake_openmp.yml
+++ b/.github/workflows/cmake_openmp.yml
@@ -12,7 +12,7 @@ jobs:
   linux:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - run: |
           sudo apt-get install libopenblas-dev liblapack-dev
           mkdir out

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
       - name: Install OS dependencies
         run: |
           sudo apt-get install doxygen
@@ -23,7 +23,7 @@ jobs:
         run: |
           cd docs/src && make docs && touch ../.nojekyll
       - name: Deploy
-        uses: JamesIves/github-pages-deploy-action@v4.7.6
+        uses: JamesIves/github-pages-deploy-action@v4.8.0
         with:
           branch: gh-pages # The branch the action should deploy to.
           folder: docs # The folder the action should deploy.

--- a/.github/workflows/gpu.yml
+++ b/.github/workflows/gpu.yml
@@ -10,8 +10,8 @@ jobs:
   linux:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: Jimver/cuda-toolkit@v0.2.30
+      - uses: actions/checkout@v7
+      - uses: Jimver/cuda-toolkit@v0.2.35
         id: cuda-toolkit
         with:
           method: network

--- a/.github/workflows/mkl_interface_mismatch.yml
+++ b/.github/workflows/mkl_interface_mismatch.yml
@@ -42,7 +42,7 @@ jobs:
         echo "LD_LIBRARY_PATH=$ONEAPI/mkl/latest/lib/intel64:$ONEAPI/compiler/latest/lib:$LD_LIBRARY_PATH" >> $GITHUB_ENV
 
     - name: Checkout project code
-      uses: actions/checkout@v6
+      uses: actions/checkout@v7
 
     - name: Build MKL library
       run: |

--- a/.github/workflows/valgrind.yml
+++ b/.github/workflows/valgrind.yml
@@ -12,7 +12,7 @@ jobs:
   linux:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - run: sudo apt-get update
       - run: sudo apt-get install libopenblas-dev liblapack-dev valgrind
       - run: make OPT="-O3 -g"
@@ -24,6 +24,6 @@ jobs:
   mac-leaks:
     runs-on: macos-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - run: make accelerate OPT="-O3 -g"
       - run: leaks --atExit -- out/run_tests_accelerate


### PR DESCRIPTION
## Summary

Update workflow action pins across the repository.

Changes include:
- `actions/checkout@v6` -> `actions/checkout@v7`
- `Jimver/cuda-toolkit@v0.2.30` -> `Jimver/cuda-toolkit@v0.2.35`
- `JamesIves/github-pages-deploy-action@v4.7.6` -> `JamesIves/github-pages-deploy-action@v4.8.0`

## Why

Moves remaining workflow actions to Node 24-capable releases and keeps checkout current.

## Validation

- Inspected workflow diffs
- Ran `git diff --check`
- Verified changed workflow action metadata no longer reports `node20`