### PR TITLE
Makefile: clean spectral-cone objects regardless of build flags

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -247,7 +247,7 @@ $(OUT)/demo_socp_gpu_indirect: test/random_socp_prob.c $(OUT)/libscsgpuindir.a
 
 .PHONY: clean purge
 clean:
-	@rm -rf $(TARGETS) $(SCS_O) $(SCS_INDIR_O) $(SCS_MKL_O) $(SCS_OBJECTS) $(AMD_OBJS) $(LDL_OBJS) $(LINSYS)/*.o $(DIRSRC)/*.o $(INDIRSRC)/*.o $(DENSESRC)/*.o $(MKLSRC)/*.o $(ACCELSRC)/*.o $(GPUDIR)/*.o $(GPUINDIR)/*.o $(LINSYS)/gpu/*.o
+	@rm -rf $(TARGETS) $(SCS_O) $(SCS_INDIR_O) $(SCS_MKL_O) $(SCS_OBJECTS) $(AMD_OBJS) $(LDL_OBJS) $(LINSYS)/*.o $(DIRSRC)/*.o $(INDIRSRC)/*.o $(DENSESRC)/*.o $(MKLSRC)/*.o $(ACCELSRC)/*.o $(GPUDIR)/*.o $(GPUINDIR)/*.o $(LINSYS)/gpu/*.o src/spectral_cones/*.o src/spectral_cones/*/*.o
 	@rm -rf $(OUT)/*.dSYM
 	@rm -rf matlab/*.mex*
 	@rm -rf .idea


### PR DESCRIPTION
Fixes the developer-side half of #409: `make clean`/`purge` without `USE_SPECTRAL_CONES=1` leaves the spectral `.o` files behind, so later builds with different flags (DLONG, sanitizers, -O level) silently link stale objects compiled under the old configuration. Under DLONG the struct-layout mismatch reads pointer halves as integer fields — producing exactly the irreproducible segfault/NaN/corrupted-solution heisenbugs chased in #409's local reproduction (which this explains and retracts; the CI failures on fresh runners remain a separate open issue). Verified: build spectral objects with the flag, `make clean` without it now removes all 8.

🤖 Generated with [Claude Code](https://claude.com/claude-code)