### PR TITLE
Bump version: 3.2.11 → 3.3.0

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 3.2.11
+current_version = 3.3.0
 
 [bumpversion:file:README.md]
 

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -10,7 +10,7 @@ authors:
 - family-names: "Boyd"
   given-names: "Stephen"
 title: "SCS: Splitting Conic Solver"
-version: 3.2.11
+version: 3.3.0
 date-released: 2023
 url: "https://github.com/cvxgrp/scs"
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@ cmake_minimum_required(VERSION 3.10)
 project(
   scs
   LANGUAGES C
-  VERSION 3.2.11)
+  VERSION 3.3.0)
 
 # Standard GNU install directories (lib, bin, include, etc.)
 include(GNUInstallDirs)

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/scs.svg?label=Conda%20downloads)](https://anaconda.org/conda-forge/scs)
 
 SCS (`splitting conic solver`) is a numerical optimization package for solving
-large-scale convex cone problems. The current version is `3.2.11`.
+large-scale convex cone problems. The current version is `3.3.0`.
 
 The full documentation is available [here](https://www.cvxgrp.org/scs/).
 

--- a/docs/src/Doxyfile
+++ b/docs/src/Doxyfile
@@ -38,7 +38,7 @@ PROJECT_NAME           = "SCS"
 # could be handy for archiving the generated documentation or if some version
 # control system is used.
 
-PROJECT_NUMBER         = 3.2.11
+PROJECT_NUMBER         = 3.3.0
 
 # Using the PROJECT_BRIEF tag one can provide an optional one line description
 # for a project that appears at the top of each page and should give viewer a

--- a/docs/src/citing/index.rst
+++ b/docs/src/citing/index.rst
@@ -48,7 +48,7 @@ If you wish to cite SCS, please use any of the following:
 
         @misc{scs,
             author       = {Brendan O'Donoghue and Eric Chu and Neal Parikh and Stephen Boyd},
-            title        = {{SCS}: Splitting Conic Solver, version 3.2.11},
+            title        = {{SCS}: Splitting Conic Solver, version 3.3.0},
             howpublished = {\url{https://github.com/cvxgrp/scs}},
             month        = nov,
             year         = 2023

--- a/docs/src/conf.py
+++ b/docs/src/conf.py
@@ -24,7 +24,7 @@ copyright = "2021, Brendan O'Donoghue"
 author = "Brendan O'Donoghue"
 
 # The full version, including alpha/beta/rc tags
-__version__ = "3.2.11"
+__version__ = "3.3.0"
 
 release = __version__
 version = __version__

--- a/include/glbopts.h
+++ b/include/glbopts.h
@@ -23,7 +23,7 @@ extern "C" {
 
 /* SCS VERSION NUMBER ----------------------------------------------     */
 /* string literals automatically null-terminated */
-#define SCS_VERSION ("3.2.11")
+#define SCS_VERSION ("3.3.0")
 
 /* verbosity level */
 #ifndef VERBOSITY


### PR DESCRIPTION
Minor version bump via `bumpversion minor` (.bumpversion.cfg), covering all tracked locations: README, CITATION.cff, glbopts.h (`SCS_VERSION`), CMakeLists.txt, docs conf.py/Doxyfile/citing. Version-only change — rolls up the recently merged equilibration, eigCG deflation, CG retune, certificate hardening, adaptive diagonal rescaling, and spectral projection fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)