### PR TITLE
Rank-one (diagonal congruence) metrics for PSD cone blocks

### DIFF
--- a/include/cones.h
+++ b/include/cones.h
@@ -30,6 +30,15 @@ struct SCS_CONE_WORK {
   ScsCone *k; /* original cone information */
   scs_int *cone_boundaries;
   scs_int cone_boundaries_len;
+  /* Per boundary entry: matrix dimension n if the block is a real PSD
+   * cone (svec length n(n+1)/2), else 0. PSD blocks admit a richer
+   * cone-invariant metric than a single scalar: any svec-diagonal
+   * weight of the rank-one form w_ij = delta_i * delta_j (a diagonal
+   * congruence X -> DXD). enforce_cone_boundaries fits this form for
+   * PSD blocks instead of collapsing them to one value. */
+  scs_int *cone_boundaries_psd_n;
+  /* scratch for PSD diagonal-congruence factors, length max PSD dim */
+  scs_float *psd_gamma;
   scs_int scaled_cones; /* boolean, whether the cones have been scaled */
   scs_float *s;         /* used for Moreau decomposition in projection */
   scs_int m;            /* total length of cone */

--- a/include/cones.h
+++ b/include/cones.h
@@ -96,7 +96,8 @@ scs_int SCS(proj_dual_cone)(scs_float *x, ScsConeWork *c,
 void SCS(finish_cone)(ScsConeWork *c);
 void SCS(set_r_y)(const ScsConeWork *c, scs_float scale, scs_float *r_y);
 void SCS(enforce_cone_boundaries)(const ScsConeWork *c, scs_float *vec,
-                                  scs_float (*f)(const scs_float *, scs_int));
+                                  scs_float (*f)(const scs_float *, scs_int),
+                                  scs_int psd_rank1);
 
 #ifdef __cplusplus
 }

--- a/linsys/scs_matrix.c
+++ b/linsys/scs_matrix.c
@@ -325,6 +325,66 @@ static void compute_ruiz_mats(ScsMatrix *P, ScsMatrix *A, const scs_float *bt,
  * equilibration the b/c entries count toward their row/column averages,
  * and the tau norms average over their own lengths.
  */
+/* One-shot post-equilibration pass: rank-one fit of the (rms) row-norm
+ * profile on real PSD blocks only. All other rows, the whole E, and the
+ * tau scalar are left untouched (identity scaling), so this pass moves
+ * nothing outside the PSD blocks. Kept outside the iterated Ruiz/l2
+ * loop: repeated fitting compounds pass over pass and destabilizes. */
+static void compute_l2_mats_psd_fit(ScsMatrix *P, ScsMatrix *A,
+                                    const scs_float *bt, const scs_float *ct,
+                                    scs_float *Dt, scs_float *Et,
+                                    scs_float *st_out, ScsConeWork *cone) {
+  scs_int i, j, seg, count;
+  scs_float *rcnt = (scs_float *)scs_calloc(A->m, sizeof(scs_float));
+
+  /* rms row norms of [A bt] (as in compute_l2_mats) */
+  for (i = 0; i < A->m; ++i) {
+    Dt[i] = bt[i] * bt[i];
+    if (rcnt) {
+      rcnt[i] = 1.;
+    }
+  }
+  for (i = 0; i < A->n; ++i) {
+    for (j = A->p[i]; j < A->p[i + 1]; ++j) {
+      Dt[A->i[j]] += A->x[j] * A->x[j];
+      if (rcnt) {
+        rcnt[A->i[j]] += 1.;
+      }
+    }
+  }
+  for (i = 0; i < A->m; ++i) {
+    if (rcnt) {
+      Dt[i] /= rcnt[i];
+    }
+    Dt[i] = SQRTF(Dt[i]);
+  }
+  scs_free(rcnt);
+
+  /* rank-one fit on PSD blocks, identity elsewhere */
+  SCS(enforce_cone_boundaries)(cone, Dt, &SCS(mean), 1);
+  count = cone->cone_boundaries[0];
+  for (i = 0; i < count; ++i) {
+    Dt[i] = 1.0;
+  }
+  for (seg = 1; seg < cone->cone_boundaries_len; ++seg) {
+    scs_int delta = cone->cone_boundaries[seg];
+    if (cone->cone_boundaries_psd_n[seg] > 1) {
+      for (i = count; i < count + delta; ++i) {
+        Dt[i] = SAFEDIV_POS(1.0, SQRTF(apply_limit(Dt[i])));
+      }
+    } else {
+      for (i = count; i < count + delta; ++i) {
+        Dt[i] = 1.0;
+      }
+    }
+    count += delta;
+  }
+  for (i = 0; i < A->n; ++i) {
+    Et[i] = 1.0;
+  }
+  *st_out = 1.0;
+}
+
 static void compute_l2_mats(ScsMatrix *P, ScsMatrix *A, const scs_float *bt,
                             const scs_float *ct, scs_float *Dt, scs_float *Et,
                             scs_float *st_out, ScsConeWork *cone) {
@@ -557,6 +617,21 @@ ScsScaling *SCS(normalize_a_p)(ScsMatrix *P, ScsMatrix *A, const scs_float *b,
   for (i = 0; i < NUM_L2_PASSES; ++i) {
     compute_l2_mats(P, A, bt, ct, Dt, Et, &st, cone);
     rescale(P, A, bt, ct, st, Dt, Et, scal, cone);
+  }
+  /* One post-equilibration rank-one fit pass for PSD blocks: a single
+   * shot (outside the iterated loop, where repeated fitting compounds
+   * and destabilizes) capturing the static within-block structure that
+   * the scalar-per-block passes cannot express. No-op without PSD
+   * cones or when the profile is flat. */
+  if (cone->cone_boundaries_psd_n) {
+    scs_int has_psd = 0;
+    for (i = 0; i < cone->cone_boundaries_len; ++i) {
+      has_psd |= (cone->cone_boundaries_psd_n[i] > 1);
+    }
+    if (has_psd) {
+      compute_l2_mats_psd_fit(P, A, bt, ct, Dt, Et, &st, cone);
+      rescale(P, A, bt, ct, st, Dt, Et, scal, cone);
+    }
   }
   scs_free(Dt);
   scs_free(Et);

--- a/linsys/scs_matrix.c
+++ b/linsys/scs_matrix.c
@@ -325,65 +325,6 @@ static void compute_ruiz_mats(ScsMatrix *P, ScsMatrix *A, const scs_float *bt,
  * equilibration the b/c entries count toward their row/column averages,
  * and the tau norms average over their own lengths.
  */
-/* One-shot post-equilibration pass: rank-one fit of the (rms) row-norm
- * profile on real PSD blocks only. All other rows, the whole E, and the
- * tau scalar are left untouched (identity scaling), so this pass moves
- * nothing outside the PSD blocks. Kept outside the iterated Ruiz/l2
- * loop: repeated fitting compounds pass over pass and destabilizes. */
-static void compute_l2_mats_psd_fit(ScsMatrix *P, ScsMatrix *A,
-                                    const scs_float *bt, const scs_float *ct,
-                                    scs_float *Dt, scs_float *Et,
-                                    scs_float *st_out, ScsConeWork *cone) {
-  scs_int i, j, seg, count;
-  scs_float *rcnt = (scs_float *)scs_calloc(A->m, sizeof(scs_float));
-
-  /* rms row norms of [A bt] (as in compute_l2_mats) */
-  for (i = 0; i < A->m; ++i) {
-    Dt[i] = bt[i] * bt[i];
-    if (rcnt) {
-      rcnt[i] = 1.;
-    }
-  }
-  for (i = 0; i < A->n; ++i) {
-    for (j = A->p[i]; j < A->p[i + 1]; ++j) {
-      Dt[A->i[j]] += A->x[j] * A->x[j];
-      if (rcnt) {
-        rcnt[A->i[j]] += 1.;
-      }
-    }
-  }
-  for (i = 0; i < A->m; ++i) {
-    if (rcnt) {
-      Dt[i] /= rcnt[i];
-    }
-    Dt[i] = SQRTF(Dt[i]);
-  }
-  scs_free(rcnt);
-
-  /* rank-one fit on PSD blocks, identity elsewhere */
-  SCS(enforce_cone_boundaries)(cone, Dt, &SCS(mean), 1);
-  count = cone->cone_boundaries[0];
-  for (i = 0; i < count; ++i) {
-    Dt[i] = 1.0;
-  }
-  for (seg = 1; seg < cone->cone_boundaries_len; ++seg) {
-    scs_int delta = cone->cone_boundaries[seg];
-    if (cone->cone_boundaries_psd_n[seg] > 1) {
-      for (i = count; i < count + delta; ++i) {
-        Dt[i] = SAFEDIV_POS(1.0, SQRTF(apply_limit(Dt[i])));
-      }
-    } else {
-      for (i = count; i < count + delta; ++i) {
-        Dt[i] = 1.0;
-      }
-    }
-    count += delta;
-  }
-  for (i = 0; i < A->n; ++i) {
-    Et[i] = 1.0;
-  }
-  *st_out = 1.0;
-}
 
 static void compute_l2_mats(ScsMatrix *P, ScsMatrix *A, const scs_float *bt,
                             const scs_float *ct, scs_float *Dt, scs_float *Et,
@@ -618,21 +559,7 @@ ScsScaling *SCS(normalize_a_p)(ScsMatrix *P, ScsMatrix *A, const scs_float *b,
     compute_l2_mats(P, A, bt, ct, Dt, Et, &st, cone);
     rescale(P, A, bt, ct, st, Dt, Et, scal, cone);
   }
-  /* One post-equilibration rank-one fit pass for PSD blocks: a single
-   * shot (outside the iterated loop, where repeated fitting compounds
-   * and destabilizes) capturing the static within-block structure that
-   * the scalar-per-block passes cannot express. No-op without PSD
-   * cones or when the profile is flat. */
-  if (cone->cone_boundaries_psd_n) {
-    scs_int has_psd = 0;
-    for (i = 0; i < cone->cone_boundaries_len; ++i) {
-      has_psd |= (cone->cone_boundaries_psd_n[i] > 1);
-    }
-    if (has_psd) {
-      compute_l2_mats_psd_fit(P, A, bt, ct, Dt, Et, &st, cone);
-      rescale(P, A, bt, ct, st, Dt, Et, scal, cone);
-    }
-  }
+
   scs_free(Dt);
   scs_free(Et);
   scs_free(bt);

--- a/linsys/scs_matrix.c
+++ b/linsys/scs_matrix.c
@@ -264,7 +264,7 @@ static void compute_ruiz_mats(ScsMatrix *P, ScsMatrix *A, const scs_float *bt,
   }
 
   /* accumulate D across each cone  */
-  SCS(enforce_cone_boundaries)(cone, Dt, &SCS(norm_inf));
+  SCS(enforce_cone_boundaries)(cone, Dt, &SCS(norm_inf), 0);
 
   /* invert temporary vec to form D */
   for (i = 0; i < A->m; ++i) {
@@ -365,7 +365,7 @@ static void compute_l2_mats(ScsMatrix *P, ScsMatrix *A, const scs_float *bt,
   }
 
   /* accumulate D across each cone  */
-  SCS(enforce_cone_boundaries)(cone, Dt, &SCS(mean));
+  SCS(enforce_cone_boundaries)(cone, Dt, &SCS(mean), 0);
 
   for (i = 0; i < A->m; ++i) {
     Dt[i] = SQRTF(apply_limit(Dt[i]));

--- a/src/cones.c
+++ b/src/cones.c
@@ -393,10 +393,26 @@ static void fit_psd_block_weights(scs_float *vec, scs_int n) {
   if (!ell) {
     return; /* leave profile as-is; caller falls back to scalar */
   }
+  /* Floor entries relative to the block max: (near-)zero rows carry no
+   * information about the block's scale structure (e.g. unconstrained
+   * off-diagonal svec rows are exactly zero in the equilibration
+   * profile) and an absolute floor lets them dominate the fit. */
+  {
+    scs_float vmax = 0., vfloor;
+    scs_int sz = (n * (n + 1)) / 2;
+    for (i = 0; i < sz; ++i) {
+      vmax = MAX(vmax, vec[i]);
+    }
+    vfloor = MAX(1e-3 * vmax, 1e-12);
+    for (i = 0; i < sz; ++i) {
+      vec[i] = MAX(vec[i], vfloor);
+    }
+  }
+
   /* rhs_k = 2 y_kk + sum_{j != k} y_kj */
   for (j = 0; j < n; ++j) {
     for (i = j; i < n; ++i) {
-      scs_float y = log(MAX(vec[svec_idx(i, j, n)], 1e-12));
+      scs_float y = log(vec[svec_idx(i, j, n)]);
       if (i == j) {
         ell[i] += 2. * y;
       } else {

--- a/src/cones.c
+++ b/src/cones.c
@@ -422,17 +422,24 @@ static void fit_psd_block_weights(scs_float *vec, scs_int n) {
   scs_free(ell);
 }
 
-/* The function f aggregates the entries within each cone. Real PSD
- * blocks instead get the rank-one (diagonal congruence) fit, which is
- * cone-invariant and strictly more expressive than a single scalar. */
+/* The function f aggregates the entries within each cone. With
+ * psd_rank1 set, real PSD blocks instead get the rank-one (diagonal
+ * congruence) fit, which is cone-invariant and strictly more
+ * expressive than a single scalar. The fit is only safe for the
+ * one-shot dynamic metric update: applied inside the iterated Ruiz
+ * equilibration loop it compounds pass over pass instead of
+ * contracting and destroys the scaling (mcp100 diverges), so the
+ * equilibration call sites keep the scalar collapse. */
 void SCS(enforce_cone_boundaries)(const ScsConeWork *c, scs_float *vec,
-                                  scs_float (*f)(const scs_float *, scs_int)) {
+                                  scs_float (*f)(const scs_float *, scs_int),
+                                  scs_int psd_rank1) {
   scs_int i, j, delta;
   scs_int count = c->cone_boundaries[0];
   scs_float wrk;
   for (i = 1; i < c->cone_boundaries_len; ++i) {
     delta = c->cone_boundaries[i];
-    if (c->cone_boundaries_psd_n && c->cone_boundaries_psd_n[i] > 1) {
+    if (psd_rank1 && c->cone_boundaries_psd_n &&
+        c->cone_boundaries_psd_n[i] > 1) {
       fit_psd_block_weights(&(vec[count]), c->cone_boundaries_psd_n[i]);
     } else {
       wrk = f(&(vec[count]), delta);

--- a/src/cones.c
+++ b/src/cones.c
@@ -390,7 +390,8 @@ static void fit_psd_block_weights(scs_float *vec, scs_int n) {
   scs_float rhs_sum = 0., corr, li, lmean = 0., base = 0., beta = 0.5;
   scs_float lo = SQRTF(DIAG_SCALE_MULT_MIN), hi = SQRTF(DIAG_SCALE_MULT_MAX);
   scs_float sb;
-  const char *beta_env = getenv("SCS_PSD_FIT_BETA"); /* TEMP: sweep knob */
+  const char *beta_env = getenv("SCS_PSD_FIT_BETA");     /* TEMP: sweep */
+  const char *cent_env = getenv("SCS_PSD_FIT_CENTER");    /* TEMP: sweep */
   scs_float *ell = (scs_float *)scs_calloc(n, sizeof(scs_float));
   if (!ell) {
     return; /* leave profile as-is; caller falls back to scalar */
@@ -398,11 +399,19 @@ static void fit_psd_block_weights(scs_float *vec, scs_int n) {
   if (beta_env) {
     beta = (scs_float)atof(beta_env);
   }
-  /* the scalar the historical code would have used: arithmetic mean */
-  for (i = 0; i < sz; ++i) {
-    base += vec[i];
+  /* block center: arithmetic mean (the historical scalar) by default,
+   * geometric mean when SCS_PSD_FIT_CENTER=geo (TEMP ablation knob) */
+  if (cent_env && cent_env[0] == 'g') {
+    for (i = 0; i < sz; ++i) {
+      base += log(MAX(vec[i], 1e-12));
+    }
+    base = exp(base / (scs_float)sz);
+  } else {
+    for (i = 0; i < sz; ++i) {
+      base += vec[i];
+    }
+    base /= (scs_float)sz;
   }
-  base /= (scs_float)sz;
   /* rhs_k = 2 y_kk + sum_{j != k} y_kj */
   for (j = 0; j < n; ++j) {
     for (i = j; i < n; ++i) {

--- a/src/cones.c
+++ b/src/cones.c
@@ -385,14 +385,24 @@ static scs_int svec_idx(scs_int i, scs_int j, scs_int n) {
  * [DIAG_SCALE_MULT_MIN, DIAG_SCALE_MULT_MAX], preserving rank-one
  * structure (clamping products directly would break it). */
 static void fit_psd_block_weights(scs_float *vec, scs_int n) {
-  scs_int i, j;
+  scs_int i, j, sz = (n * (n + 1)) / 2;
   scs_float alpha = (scs_float)(n + 2);
-  scs_float rhs_sum = 0., corr, li;
+  scs_float rhs_sum = 0., corr, li, lmean = 0., base = 0., beta = 0.5;
   scs_float lo = SQRTF(DIAG_SCALE_MULT_MIN), hi = SQRTF(DIAG_SCALE_MULT_MAX);
+  scs_float sb;
+  const char *beta_env = getenv("SCS_PSD_FIT_BETA"); /* TEMP: sweep knob */
   scs_float *ell = (scs_float *)scs_calloc(n, sizeof(scs_float));
   if (!ell) {
     return; /* leave profile as-is; caller falls back to scalar */
   }
+  if (beta_env) {
+    beta = (scs_float)atof(beta_env);
+  }
+  /* the scalar the historical code would have used: arithmetic mean */
+  for (i = 0; i < sz; ++i) {
+    base += vec[i];
+  }
+  base /= (scs_float)sz;
   /* rhs_k = 2 y_kk + sum_{j != k} y_kj */
   for (j = 0; j < n; ++j) {
     for (i = j; i < n; ++i) {
@@ -411,7 +421,17 @@ static void fit_psd_block_weights(scs_float *vec, scs_int n) {
   /* (alpha I + 11')^{-1} rhs = rhs/alpha - 1 (1'rhs) / (alpha(alpha+n)) */
   corr = rhs_sum / (alpha * (alpha + (scs_float)n));
   for (i = 0; i < n; ++i) {
-    li = exp(ell[i] / alpha - corr);
+    ell[i] = ell[i] / alpha - corr;
+    lmean += ell[i];
+  }
+  lmean /= (scs_float)n;
+  /* Center the structured part on the historical scalar (flat profile
+   * reproduces it exactly) and damp the deviation by beta: the new
+   * degrees of freedom move conservatively, like every other damped
+   * step in the adaptive metric. */
+  sb = SQRTF(base);
+  for (i = 0; i < n; ++i) {
+    li = sb * exp(beta * (ell[i] - lmean));
     ell[i] = MIN(MAX(li, lo), hi);
   }
   for (j = 0; j < n; ++j) {

--- a/src/cones.c
+++ b/src/cones.c
@@ -385,32 +385,13 @@ static scs_int svec_idx(scs_int i, scs_int j, scs_int n) {
  * [DIAG_SCALE_MULT_MIN, DIAG_SCALE_MULT_MAX], preserving rank-one
  * structure (clamping products directly would break it). */
 static void fit_psd_block_weights(scs_float *vec, scs_int n) {
-  scs_int i, j, sz = (n * (n + 1)) / 2;
+  scs_int i, j;
   scs_float alpha = (scs_float)(n + 2);
-  scs_float rhs_sum = 0., corr, li, lmean = 0., base = 0., beta = 0.5;
+  scs_float rhs_sum = 0., corr, li;
   scs_float lo = SQRTF(DIAG_SCALE_MULT_MIN), hi = SQRTF(DIAG_SCALE_MULT_MAX);
-  scs_float sb;
-  const char *beta_env = getenv("SCS_PSD_FIT_BETA");     /* TEMP: sweep */
-  const char *cent_env = getenv("SCS_PSD_FIT_CENTER");    /* TEMP: sweep */
   scs_float *ell = (scs_float *)scs_calloc(n, sizeof(scs_float));
   if (!ell) {
     return; /* leave profile as-is; caller falls back to scalar */
-  }
-  if (beta_env) {
-    beta = (scs_float)atof(beta_env);
-  }
-  /* block center: arithmetic mean (the historical scalar) by default,
-   * geometric mean when SCS_PSD_FIT_CENTER=geo (TEMP ablation knob) */
-  if (cent_env && cent_env[0] == 'g') {
-    for (i = 0; i < sz; ++i) {
-      base += log(MAX(vec[i], 1e-12));
-    }
-    base = exp(base / (scs_float)sz);
-  } else {
-    for (i = 0; i < sz; ++i) {
-      base += vec[i];
-    }
-    base /= (scs_float)sz;
   }
   /* rhs_k = 2 y_kk + sum_{j != k} y_kj */
   for (j = 0; j < n; ++j) {
@@ -430,17 +411,7 @@ static void fit_psd_block_weights(scs_float *vec, scs_int n) {
   /* (alpha I + 11')^{-1} rhs = rhs/alpha - 1 (1'rhs) / (alpha(alpha+n)) */
   corr = rhs_sum / (alpha * (alpha + (scs_float)n));
   for (i = 0; i < n; ++i) {
-    ell[i] = ell[i] / alpha - corr;
-    lmean += ell[i];
-  }
-  lmean /= (scs_float)n;
-  /* Center the structured part on the historical scalar (flat profile
-   * reproduces it exactly) and damp the deviation by beta: the new
-   * degrees of freedom move conservatively, like every other damped
-   * step in the adaptive metric. */
-  sb = SQRTF(base);
-  for (i = 0; i < n; ++i) {
-    li = sb * exp(beta * (ell[i] - lmean));
+    li = exp(ell[i] / alpha - corr);
     ell[i] = MIN(MAX(li, lo), hi);
   }
   for (j = 0; j < n; ++j) {

--- a/src/cones.c
+++ b/src/cones.c
@@ -307,6 +307,10 @@ void SCS(finish_cone)(ScsConeWork *c) {
 #endif
   if (c->cone_boundaries)
     scs_free(c->cone_boundaries);
+  if (c->cone_boundaries_psd_n)
+    scs_free(c->cone_boundaries_psd_n);
+  if (c->psd_gamma)
+    scs_free(c->psd_gamma);
   if (c->r_box_inv)
     scs_free(c->r_box_inv);
   if (c->s)
@@ -362,7 +366,65 @@ void SCS(set_r_y)(const ScsConeWork *c, scs_float scale, scs_float *r_y) {
   }
 }
 
-/* The function f aggregates the entries within each cone */
+/* svec packed index of entry (i, j), i >= j, in an n x n lower
+ * triangle stored column-major. */
+static scs_int svec_idx(scs_int i, scs_int j, scs_int n) {
+  return j * n - (j * (j - 1)) / 2 + (i - j);
+}
+
+/* Fit the rank-one form w_ij = delta_i * delta_j to a positive profile
+ * on one PSD block (svec packed, length n(n+1)/2) by least squares in
+ * log space, and overwrite the block with the fitted values. This is
+ * the richest svec-diagonal metric that maps the PSD cone to itself
+ * (the diagonal congruence X -> diag(delta) X diag(delta)), so unlike
+ * generic cones the block need not collapse to a single scalar.
+ *
+ * Normal equations: minimizing sum_{i<=j} (l_i + l_j - y_ij)^2 gives
+ * A'A = (n+2) I + 11', inverted in closed form by Sherman-Morrison.
+ * The fitted delta_i are clamped so every product w_ij stays within
+ * [DIAG_SCALE_MULT_MIN, DIAG_SCALE_MULT_MAX], preserving rank-one
+ * structure (clamping products directly would break it). */
+static void fit_psd_block_weights(scs_float *vec, scs_int n) {
+  scs_int i, j;
+  scs_float alpha = (scs_float)(n + 2);
+  scs_float rhs_sum = 0., corr, li;
+  scs_float lo = SQRTF(DIAG_SCALE_MULT_MIN), hi = SQRTF(DIAG_SCALE_MULT_MAX);
+  scs_float *ell = (scs_float *)scs_calloc(n, sizeof(scs_float));
+  if (!ell) {
+    return; /* leave profile as-is; caller falls back to scalar */
+  }
+  /* rhs_k = 2 y_kk + sum_{j != k} y_kj */
+  for (j = 0; j < n; ++j) {
+    for (i = j; i < n; ++i) {
+      scs_float y = log(MAX(vec[svec_idx(i, j, n)], 1e-12));
+      if (i == j) {
+        ell[i] += 2. * y;
+      } else {
+        ell[i] += y;
+        ell[j] += y;
+      }
+    }
+  }
+  for (i = 0; i < n; ++i) {
+    rhs_sum += ell[i];
+  }
+  /* (alpha I + 11')^{-1} rhs = rhs/alpha - 1 (1'rhs) / (alpha(alpha+n)) */
+  corr = rhs_sum / (alpha * (alpha + (scs_float)n));
+  for (i = 0; i < n; ++i) {
+    li = exp(ell[i] / alpha - corr);
+    ell[i] = MIN(MAX(li, lo), hi);
+  }
+  for (j = 0; j < n; ++j) {
+    for (i = j; i < n; ++i) {
+      vec[svec_idx(i, j, n)] = ell[i] * ell[j];
+    }
+  }
+  scs_free(ell);
+}
+
+/* The function f aggregates the entries within each cone. Real PSD
+ * blocks instead get the rank-one (diagonal congruence) fit, which is
+ * cone-invariant and strictly more expressive than a single scalar. */
 void SCS(enforce_cone_boundaries)(const ScsConeWork *c, scs_float *vec,
                                   scs_float (*f)(const scs_float *, scs_int)) {
   scs_int i, j, delta;
@@ -370,9 +432,13 @@ void SCS(enforce_cone_boundaries)(const ScsConeWork *c, scs_float *vec,
   scs_float wrk;
   for (i = 1; i < c->cone_boundaries_len; ++i) {
     delta = c->cone_boundaries[i];
-    wrk = f(&(vec[count]), delta);
-    for (j = count; j < count + delta; ++j) {
-      vec[j] = wrk;
+    if (c->cone_boundaries_psd_n && c->cone_boundaries_psd_n[i] > 1) {
+      fit_psd_block_weights(&(vec[count]), c->cone_boundaries_psd_n[i]);
+    } else {
+      wrk = f(&(vec[count]), delta);
+      for (j = count; j < count + delta; ++j) {
+        vec[j] = wrk;
+      }
     }
     count += delta;
   }
@@ -394,13 +460,16 @@ void set_cone_boundaries(const ScsCone *k, ScsConeWork *c) {
       k->qsize + k->ssize + k->cssize + k->ed + k->ep + k->psize;
 #endif
   scs_int *b = (scs_int *)scs_calloc(total_cones + 1, sizeof(scs_int));
+  scs_int *psd_n = (scs_int *)scs_calloc(total_cones + 1, sizeof(scs_int));
 
   /* Cones that can be scaled independently */
   b[count++] = k->z + k->l + k->bsize;
   for (i = 0; i < k->qsize; ++i)
     b[count++] = k->q[i];
-  for (i = 0; i < k->ssize; ++i)
+  for (i = 0; i < k->ssize; ++i) {
+    psd_n[count] = k->s[i];
     b[count++] = get_sd_cone_size(k->s[i]);
+  }
   for (i = 0; i < k->cssize; ++i)
     b[count++] = get_csd_cone_size(k->cs[i]);
   for (i = 0; i < k->ep + k->ed; ++i)
@@ -421,6 +490,7 @@ void set_cone_boundaries(const ScsCone *k, ScsConeWork *c) {
 
   c->cone_boundaries = b;
   c->cone_boundaries_len = total_cones + 1;
+  c->cone_boundaries_psd_n = psd_n;
 }
 
 static scs_int get_full_cone_dims(const ScsCone *k) {
@@ -842,6 +912,7 @@ static scs_int set_up_cone_work_spaces(ScsConeWork *c, const ScsCone *k) {
    * 'e' stores eigenvalues, 'isuppz' supports them. Shared by Real/Complex.
    */
   c->e = (scs_float *)scs_calloc(n_max, sizeof(scs_float));
+  c->psd_gamma = (scs_float *)scs_calloc(n_max, sizeof(scs_float));
   c->isuppz = (blas_int *)scs_calloc(MAX(2, 2 * n_max), sizeof(blas_int));
   if (!c->e || !c->isuppz)
     return -1;
@@ -996,8 +1067,18 @@ static scs_int set_up_ell1_cone_work_space(ScsConeWork *c, const ScsCone *k) {
 /*
  * Projection: Real Semi-Definite Cone
  */
+/* Project one svec-packed block onto the PSD cone. When rho (the
+ * block's slice of the diagonal metric R) is non-uniform it must have
+ * the rank-one structure w_ij = delta_i * delta_j (enforced by
+ * fit_psd_block_weights). The projection under the induced R^{-1}
+ * metric is then a diagonal congruence sandwich: with gamma_i =
+ * w_ii^{-1/4}, project Gamma X Gamma and unscale. Positive homogeneity
+ * of the cone makes any uniform factor in rho drop out, so the
+ * historical scalar-per-block case reduces to the unscaled path. */
 static scs_int proj_semi_definite_cone(scs_float *X, const scs_int n,
-                                       ScsConeWork *c) {
+                                       ScsConeWork *c,
+                                       const scs_float *rho) {
+  scs_int scaled = 0;
   if (n == 0)
     return 0;
   if (n == 1) {
@@ -1014,6 +1095,31 @@ static scs_int proj_semi_definite_cone(scs_float *X, const scs_int n,
   scs_float abstol = -1.0, d_f = 0.0, sq_eig;
   blas_int m = 0, d_i = 0;
   scs_int first_idx = -1;
+
+  /* Diagonal-congruence pre-scale (skip when the metric is uniform on
+   * this block so the historical path stays bit-identical). */
+  if (rho && c->psd_gamma) {
+    scs_float wmin = rho[0], wmax = rho[0];
+    for (i = 1; i < n; ++i) {
+      scs_float wii = rho[i * n - ((i - 1) * i) / 2];
+      wmin = MIN(wmin, wii);
+      wmax = MAX(wmax, wii);
+    }
+    if (wmax > wmin * (1. + 1e-12)) {
+      scs_int jj, ii;
+      scaled = 1;
+      for (i = 0; i < n; ++i) {
+        c->psd_gamma[i] = POWF(rho[i * n - ((i - 1) * i) / 2], -0.25);
+      }
+      for (jj = 0; jj < n; ++jj) {
+        scs_float gj = c->psd_gamma[jj];
+        scs_float *col = &(X[jj * n - ((jj - 1) * jj) / 2]);
+        for (ii = jj; ii < n; ++ii) {
+          col[ii - jj] *= c->psd_gamma[ii] * gj;
+        }
+      }
+    }
+  }
 
   /* Copy lower triangular part to full matrix buffer Xs */
   for (i = 0; i < n; ++i) {
@@ -1059,6 +1165,18 @@ static scs_int proj_semi_definite_cone(scs_float *X, const scs_int n,
   for (i = 0; i < n; ++i) {
     memcpy(&(X[i * n - ((i - 1) * i) / 2]), &(c->Xs[i * (n + 1)]),
            (n - i) * sizeof(scs_float));
+  }
+
+  /* Undo the congruence pre-scale */
+  if (scaled) {
+    scs_int jj, ii;
+    for (jj = 0; jj < n; ++jj) {
+      scs_float gj = c->psd_gamma[jj];
+      scs_float *col = &(X[jj * n - ((jj - 1) * jj) / 2]);
+      for (ii = jj; ii < n; ++ii) {
+        col[ii - jj] /= c->psd_gamma[ii] * gj;
+      }
+    }
   }
   return 0;
 #else
@@ -1382,7 +1500,8 @@ static scs_int proj_cone(scs_float *x, const ScsCone *k, ScsConeWork *c,
 #ifdef USE_SPECTRAL_CONES
       SPECTRAL_TIMING(SCS(tic)(&spec_mat_proj_timer);)
 #endif
-      status = proj_semi_definite_cone(&(x[count]), k->s[i], c);
+      status = proj_semi_definite_cone(&(x[count]), k->s[i], c,
+                                       r_y ? &(r_y[count]) : SCS_NULL);
 #ifdef USE_SPECTRAL_CONES
       SPECTRAL_TIMING(c->tot_time_mat_cone_proj +=
                       SCS(tocq)(&spec_mat_proj_timer);)

--- a/src/scs.c
+++ b/src/scs.c
@@ -1355,7 +1355,7 @@ static scs_int update_scale(ScsWork *w, const ScsCone *k, scs_int iter) {
             DIAG_SCALE_MULT_MAX);
       }
       /* non-polyhedral cone blocks must share a single metric entry */
-      SCS(enforce_cone_boundaries)(w->cone_work, w->scale_mults, SCS(mean));
+      SCS(enforce_cone_boundaries)(w->cone_work, w->scale_mults, &SCS(mean), 1);
     }
 
     /* update diag r vector */

--- a/test/problems/test_psd_metric.h
+++ b/test/problems/test_psd_metric.h
@@ -1,0 +1,109 @@
+#include "cones.h"
+#include "glbopts.h"
+#include "linalg.h"
+#include "minunit.h"
+#include "scs.h"
+#include "util.h"
+
+/* Tests for the PSD diagonal-congruence (rank-one svec-diagonal) metric.
+ *
+ * 1. enforce_cone_boundaries on a PSD block must return exactly
+ *    rank-one weights w_ij = delta_i * delta_j within clamp bounds.
+ * 2. proj_dual_cone under such a metric must produce a Moreau split
+ *    x = out - R^{-1} p with out in K, p in K*, and <out, p> = 0.
+ *    Memberships are verified with metric-free Euclidean projections.
+ */
+
+#define PSD_N (7)
+#define PSD_M ((PSD_N * (PSD_N + 1)) / 2)
+
+static scs_int psd_svec_idx(scs_int i, scs_int j, scs_int n) {
+  return j * n - (j * (j - 1)) / 2 + (i - j);
+}
+
+/* deterministic LCG so the test has no platform variance */
+static scs_float psd_rand(scs_int *state) {
+  *state = (scs_int)((1103515245u * (unsigned long)*state + 12345u) &
+                     0x7fffffffu);
+  return 2.0 * ((scs_float)*state / (scs_float)0x7fffffff) - 1.0;
+}
+
+static const char *test_psd_metric(void) {
+  ScsCone *k = (ScsCone *)scs_calloc(1, sizeof(ScsCone));
+  ScsConeWork *cw, *eucl;
+  scs_int s_dims[1] = {PSD_N};
+  scs_float r_y[PSD_M], prof[PSD_M], delta[PSD_N];
+  scs_float x[PSD_M], out[PSD_M], p[PSD_M], chk[PSD_M];
+  scs_float dot, nrm, dist;
+  scs_int i, j, seed = 12345;
+
+  k->ssize = 1;
+  k->s = s_dims;
+  cw = SCS(init_cone)(k, PSD_M);
+  eucl = SCS(init_cone)(k, PSD_M);
+  mu_assert("psd_metric: cone init failed", cw && eucl);
+
+  /* --- 1. rank-one fit --- */
+  for (i = 0; i < PSD_M; ++i) {
+    prof[i] = exp(1.5 * psd_rand(&seed)); /* arbitrary positive profile */
+  }
+  SCS(enforce_cone_boundaries)(cw, prof, &SCS(mean));
+  for (i = 0; i < PSD_N; ++i) {
+    delta[i] = SQRTF(prof[psd_svec_idx(i, i, PSD_N)]);
+  }
+  for (j = 0; j < PSD_N; ++j) {
+    for (i = j; i < PSD_N; ++i) {
+      scs_float w = prof[psd_svec_idx(i, j, PSD_N)];
+      mu_assert("psd_metric: fit not rank-one",
+                ABS(w - delta[i] * delta[j]) <= 1e-12 * (1. + ABS(w)));
+      mu_assert("psd_metric: fit outside clamp bounds",
+                w >= DIAG_SCALE_MULT_MIN * (1. - 1e-12) &&
+                    w <= DIAG_SCALE_MULT_MAX * (1. + 1e-12));
+    }
+  }
+
+  /* --- 2. Moreau split under the fitted metric --- */
+  memcpy(r_y, prof, PSD_M * sizeof(scs_float));
+  for (i = 0; i < PSD_M; ++i) {
+    x[i] = 2.0 * psd_rand(&seed);
+  }
+  memcpy(out, x, PSD_M * sizeof(scs_float));
+  mu_assert("psd_metric: projection failed",
+            SCS(proj_dual_cone)(out, cw, SCS_NULL, r_y) == 0);
+
+  /* p = R (out - x) must lie in K* (= K); out must lie in K. */
+  for (i = 0; i < PSD_M; ++i) {
+    p[i] = r_y[i] * (out[i] - x[i]);
+  }
+  memcpy(chk, out, PSD_M * sizeof(scs_float));
+  SCS(proj_dual_cone)(chk, eucl, SCS_NULL, SCS_NULL);
+  dist = SCS(norm_inf_diff)(chk, out, PSD_M);
+  nrm = SCS(norm_inf)(out, PSD_M);
+  mu_assert("psd_metric: primal part not in cone", dist <= 1e-9 * (1. + nrm));
+
+  memcpy(chk, p, PSD_M * sizeof(scs_float));
+  SCS(proj_dual_cone)(chk, eucl, SCS_NULL, SCS_NULL);
+  dist = SCS(norm_inf_diff)(chk, p, PSD_M);
+  nrm = SCS(norm_inf)(p, PSD_M);
+  mu_assert("psd_metric: dual part not in cone", dist <= 1e-9 * (1. + nrm));
+
+  dot = SCS(dot)(out, p, PSD_M);
+  mu_assert("psd_metric: Moreau parts not orthogonal",
+            ABS(dot) <= 1e-9 * (1. + SCS(norm_inf)(x, PSD_M)));
+
+  /* uniform metric must reproduce the Euclidean projection exactly */
+  for (i = 0; i < PSD_M; ++i) {
+    r_y[i] = 0.25;
+    out[i] = x[i];
+    chk[i] = x[i];
+  }
+  SCS(proj_dual_cone)(out, cw, SCS_NULL, r_y);
+  SCS(proj_dual_cone)(chk, eucl, SCS_NULL, SCS_NULL);
+  mu_assert("psd_metric: uniform metric deviates from Euclidean",
+            SCS(norm_inf_diff)(chk, out, PSD_M) <= 1e-13);
+
+  SCS(finish_cone)(cw);
+  SCS(finish_cone)(eucl);
+  scs_free(k);
+  return 0;
+}

--- a/test/problems/test_psd_metric.h
+++ b/test/problems/test_psd_metric.h
@@ -47,7 +47,7 @@ static const char *test_psd_metric(void) {
   for (i = 0; i < PSD_M; ++i) {
     prof[i] = exp(1.5 * psd_rand(&seed)); /* arbitrary positive profile */
   }
-  SCS(enforce_cone_boundaries)(cw, prof, &SCS(mean));
+  SCS(enforce_cone_boundaries)(cw, prof, &SCS(mean), 1);
   for (i = 0; i < PSD_N; ++i) {
     delta[i] = SQRTF(prof[psd_svec_idx(i, i, PSD_N)]);
   }

--- a/test/run_tests.c
+++ b/test/run_tests.c
@@ -52,9 +52,11 @@ _SKIP(test_validation)
 #if defined(USE_LAPACK)
 #include "problems/complex_PSD.h"
 #include "problems/sd_and_complex_sd.h"
+#include "problems/test_psd_metric.h"
 #else
 _SKIP(complex_PSD)
 _SKIP(sd_and_complex_sd)
+_SKIP(test_psd_metric)
 #endif
 
 /* solve SDPs from data files, requires blas / lapack */
@@ -108,6 +110,7 @@ static const char *all_tests(void) {
   mu_run_test(rob_gauss_cov_est);
   mu_run_test(complex_PSD);
   mu_run_test(sd_and_complex_sd);
+  mu_run_test(test_psd_metric);
   mu_run_test(hs21_tiny_qp);
   mu_run_test(hs21_tiny_qp_rw);
   mu_run_test(qafiro_tiny_qp);


### PR DESCRIPTION
## Idea

PSD blocks currently collapse to a single scalar in the adaptive diagonal rescaling, because `enforce_cone_boundaries` only knows constant-per-block metrics — the requirement being that the metric maps the cone to itself so the projection stays cheap. But the PSD cone admits a strictly richer svec-diagonal family with that property: the **diagonal congruence** `X → diag(δ)·X·diag(δ)`, i.e. weights `w_ij = δ_i·δ_j` — **n parameters per block instead of 1**, still exactly diagonal at the linear-system layer (zero fill, no factorization changes, direct and indirect solvers untouched).

## What changes

- `enforce_cone_boundaries` gains a `psd_rank1` flag: real PSD blocks get the best rank-one fit to the row profile (least squares in log space, closed form via Sherman–Morrison on `(n+2)I + 11'`), with δ clamped so all products respect the existing `DIAG_SCALE_MULT` bounds without breaking rank-one structure. Only the dynamic `scale_mults` update passes the flag; **equilibration is untouched**.
- `proj_semi_definite_cone` receives its block's `r_y` slice and, when non-uniform, projects under the induced R⁻¹ metric via a congruence sandwich (`γ_i = w_ii^{-1/4}`: scale, eig-clip, unscale — O(n²) around the O(n³) eig). Uniform blocks take the historical path bit-for-bit. The rank-one invariant is load-bearing (the sandwich reads only diagonal weights); the fit guarantees it and the unit test asserts it.
- Behavior is unchanged (bit-identical) with `adaptive_diag_scale=0` or on problems without PSD cones.

## Results (SDPLIB, eps 1e-6, 300s, independently computed KKT residuals)

Across four same-config replicate pairs on separate runs:

| | solves (4 replicates) | both-solved iters | dual res med | accuracy violations |
|---|---|---|---|---|
| master | 34 / 36 / 37 / 37 | 1.00 | 5.5e-7 | 0 |
| this PR | **40 / 39 / 40 / 40** | ~0.99 | 4.9e-7 | 0 |

Every PR replicate beats every master replicate (bands don't overlap); the gains are tail robustness (mcp500s, qap7/8, truss5, net-positive hinf churn) at neutral both-solved iteration cost and identical delivered accuracy.

## Ablation (why this exact form)

- Rank-one structure centered on the block's **arithmetic** mean: neutral (34). Geometric-mean aggregation **without** structure: neutral (34). The coherent log-space fit (natural geometric center + structure): +5/6, replicated. The interaction is the effect.
- A static variant (fit inside the Ruiz loop) **diverges**: repeated fitting compounds, and unconstrained off-diagonal svec rows are exactly zero (98% of rows on mcp instances), poisoning an absolutely-floored log fit — the fit now floors relative to the block max. A stable one-shot post-equilibration variant was implemented and benchmarked **neutral** (39 vs 40, worse both-solved ratio), so it's removed; branch history has the implementation, and a masked-LS in-loop design is the natural future attempt.
- SOC blocks admit an analogous non-diagonal family (Lorentz boosts, identity+rank-2, k+2 params) — free for the indirect solver, needs Woodbury on the direct side; deliberately out of scope here.

## Tests

`test_psd_metric`: fit exactness (rank-one to 1e-12) and clamp bounds on arbitrary profiles; Moreau split under a non-uniform metric verified on-cone via metric-free Euclidean re-projection with R-orthogonality; uniform metric ≡ Euclidean projection. Full suites 58/58 direct and indirect (DLONG and default).

🤖 Generated with [Claude Code](https://claude.com/claude-code)