### PR TITLE
Packaging: versioned sonames, relocatable CMake packages, strict C99

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,6 +25,11 @@ jobs:
       - name: Run dense tests
         if: matrix.lapack == 1
         run: out/run_tests_dense
+      - name: Install and check the versioned shared library
+        run: |
+          make install DLONG=${{ matrix.long }} USE_LAPACK=${{ matrix.lapack }} PREFIX=$PWD/_inst
+          test -L _inst/lib/libscsdir.so && test -e _inst/lib/libscsdir.so
+          readelf -d _inst/lib/libscsdir.so | grep -q 'SONAME.*libscsdir\.so\.[0-9]'
 
   windows:
     strategy:
@@ -97,3 +102,8 @@ jobs:
       - name: Run accelerate tests
         if: matrix.long == 0
         run: out/run_tests_accelerate
+      - name: Install and check the versioned shared library
+        run: |
+          make install DLONG=${{ matrix.long }} USE_LAPACK=${{ matrix.lapack }} PREFIX=$PWD/_inst
+          test -L _inst/lib/libscsdir.dylib && test -e _inst/lib/libscsdir.dylib
+          otool -D _inst/lib/libscsdir.dylib | grep -q 'libscsdir\.[0-9].*\.dylib'

--- a/.github/workflows/cmake_consume.yml
+++ b/.github/workflows/cmake_consume.yml
@@ -74,6 +74,19 @@ jobs:
           fi
           grep -q "LAPACK::LAPACK" prefix/lib/cmake/scs/scsTargets.cmake
 
+      - name: Reject an older static-package consumer
+        if: matrix.shared == 'OFF'
+        run: |
+          python3 -m venv old-cmake
+          old-cmake/bin/python -m pip install cmake==3.21.4
+          if old-cmake/bin/cmake -S test/packaging -B consume-old \
+               -DCMAKE_PREFIX_PATH="$PWD/prefix" > old.log 2>&1; then
+            echo "static consumption succeeded with CMake older than 3.22"
+            exit 1
+          fi
+          tr '\n' ' ' < old.log | tr -s ' ' | \
+            grep -q "Static scs packages require CMake 3.22"
+
       - name: Configure, build, run the consumer
         run: |
           cmake -S test/packaging -B consume-build \

--- a/.github/workflows/cmake_consume.yml
+++ b/.github/workflows/cmake_consume.yml
@@ -1,0 +1,140 @@
+---
+name: CMake install and consume
+
+on:
+  push:
+    branches: [master]
+    tags: ['*']
+  pull_request:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 6 * * 1'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  consume:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - shared: ON
+            name: shared
+          - shared: OFF
+            name: static
+
+    name: install-and-consume (${{ matrix.name }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Install LAPACK development files (build machine)
+        run: sudo apt-get update && sudo apt-get install -y liblapack-dev
+
+      - name: Configure, build, install scs
+        run: |
+          cmake -S . -B build \
+            -DBUILD_SHARED_LIBS=${{ matrix.shared }} \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DCMAKE_INSTALL_PREFIX="$PWD/prefix"
+          cmake --build build -j
+          cmake --install build
+
+      - name: Verify shared-library ABI identity
+        if: matrix.shared == 'ON'
+        run: |
+          # The loader identity must be the ABI version (major.minor), never
+          # the patch version: 3.3.1 must keep satisfying libscsdir.so.3.3.
+          soname=$(objdump -p prefix/lib/libscsdir.so | awk '/SONAME/ {print $2}')
+          echo "SONAME: $soname"
+          [ "$soname" = "libscsdir.so.3.3" ]
+          ls -l prefix/lib/libscsdir.so*
+
+      - name: Remove private build dependencies (shared only)
+        if: matrix.shared == 'ON'
+        run: |
+          # A shared-library consumer has no LAPACK interface dependency and
+          # must configure/link on a machine without LAPACK development
+          # files. (The runtime library stays, as it would for any user.)
+          sudo apt-get remove -y liblapack-dev libblas-dev
+
+      - name: Assert the export is relocatable (static only)
+        if: matrix.shared == 'OFF'
+        run: |
+          # The static export must reference dependency targets by name
+          # (LAPACK::LAPACK), never absolute build-machine provider paths.
+          if grep -nE '/[^;"]*lib(lapack|blas)' \
+               prefix/lib/cmake/scs/scsTargets.cmake; then
+            echo "static export embeds absolute provider paths"
+            exit 1
+          fi
+          grep -q "LAPACK::LAPACK" prefix/lib/cmake/scs/scsTargets.cmake
+
+      - name: Configure, build, run the consumer
+        run: |
+          cmake -S test/packaging -B consume-build \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DCMAKE_PREFIX_PATH="$PWD/prefix"
+          cmake --build consume-build -j
+          if [ "${{ matrix.shared }}" = "ON" ]; then
+            export LD_LIBRARY_PATH="$PWD/prefix/lib"
+          fi
+          ./consume-build/consume
+
+  consume-blas64:
+    # A static BLAS64 package carries its LAPACK integer width: consumers are
+    # pinned to ILP64, and one that already resolved LAPACK at the wrong
+    # width is refused rather than silently mislinked.
+    name: install-and-consume (static, BLAS64/ILP64)
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Install ILP64 and LP64 LAPACK
+        run: sudo apt-get update && sudo apt-get install -y liblapack-dev liblapack64-dev libblas64-dev
+
+      - name: Build and install static BLAS64 scs
+        run: |
+          cmake -S . -B build -DBUILD_SHARED_LIBS=OFF -DBLAS64=ON \
+            -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX="$PWD/prefix"
+          cmake --build build -j
+          cmake --install build
+
+      - name: Consumer is pinned to the 8-byte width and solves
+        run: |
+          cmake -S test/packaging -B consume-build \
+            -DCMAKE_BUILD_TYPE=Release -DCMAKE_PREFIX_PATH="$PWD/prefix"
+          grep -q lapack64 consume-build/CMakeFiles/consume.dir/link.txt
+          cmake --build consume-build -j
+          ./consume-build/consume
+
+      - name: A consumer that resolved LAPACK at the wrong width is refused
+        run: |
+          if cmake -S test/packaging -B consume-wrong \
+               -DCMAKE_PREFIX_PATH="$PWD/prefix" -DPREFIND_LAPACK_WRONG_WIDTH=ON \
+               > wrong.log 2>&1; then
+            echo "configure succeeded with a 4-byte LAPACK::LAPACK in scope"
+            exit 1
+          fi
+          tr '\n' ' ' < wrong.log | tr -s ' ' | grep -q "built with 8-byte LAPACK integers"
+
+  werror:
+    # the strict C99 build (see CMAKE_C_STANDARD) must stay warning-free;
+    # -DPROFILING=1 compiles the timing paths too
+    name: strict C99 -Werror build
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v7
+      - name: Install LAPACK development files
+        run: sudo apt-get update && sudo apt-get install -y liblapack-dev
+      - name: Build with -Werror
+        run: |
+          cmake -S . -B build-prof -DCMAKE_BUILD_TYPE=Release \
+            -DCMAKE_C_FLAGS="-DPROFILING=1 -Wall -Werror"
+          cmake --build build-prof -j

--- a/.github/workflows/cmake_mkl.yml
+++ b/.github/workflows/cmake_mkl.yml
@@ -3,10 +3,16 @@ name: CMake MKL
 
 on:
   push:
+    branches: [master]
+    tags: ['*']
   pull_request:
   workflow_dispatch:
   schedule:
     - cron: '0 6 * * 1'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   linux:
@@ -18,10 +24,18 @@ jobs:
         include:
           - blas64: OFF
             dlong: OFF
+            shared: ON
           - blas64: OFF
             dlong: ON
+            shared: ON
           - blas64: ON
             dlong: ON
+            shared: ON
+          # static row: the relocated package must drive a real Pardiso
+          # solve through find_package (dlong OFF: qp.c uses int indices)
+          - blas64: OFF
+            dlong: OFF
+            shared: OFF
 
     runs-on: ubuntu-latest
     timeout-minutes: 15
@@ -56,14 +70,27 @@ jobs:
         export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$INSTALL_DIR/lib
         mkdir build
         cd build
-        cmake -DBUILD_TESTING=ON -DBLAS64=${{ matrix.blas64 }} -DDLONG=${{ matrix.dlong }} -DCMAKE_INSTALL_PREFIX:PATH=$INSTALL_DIR ..
+        cmake -DBUILD_TESTING=ON -DBLAS64=${{ matrix.blas64 }} -DDLONG=${{ matrix.dlong }} -DBUILD_SHARED_LIBS=${{ matrix.shared }} -DCMAKE_INSTALL_PREFIX:PATH=$INSTALL_DIR ..
         make
         make install
         ctest --output-on-failure
-        # The qp.c example uses int (not scs_int) for matrix indices,
-        # so it only works with 32-bit ints (DLONG=OFF).
-        if [[ "${{ matrix.dlong }}" == "OFF" ]]; then
+        # qp.c uses int indices (DLONG=OFF) and links the shared library by hand
+        if [[ "${{ matrix.dlong }}" == "OFF" && "${{ matrix.shared }}" == "ON" ]]; then
           cd ../docs/src/examples/
           gcc -I$INSTALL_DIR/include/scs -L$INSTALL_DIR/lib/ qp.c -o qp.out -lscsmkl
           ./qp.out
         fi
+
+    - name: Static MKL export is relocatable and drives a real Pardiso solve
+      if: matrix.shared == 'OFF'
+      run: |
+        set -euo pipefail
+        # relocate the installed prefix: any surviving build-path
+        # reference breaks from here on
+        mv out relocated-prefix
+        # the packaging consumer, linked against scs::scsmkl through
+        # find_package on the relocated prefix, must solve via MKL Pardiso
+        cmake -S test/packaging -B qp-build -DSCS_COMPONENT=scsmkl \
+          -DCMAKE_PREFIX_PATH="$PWD/relocated-prefix"
+        cmake --build qp-build -j
+        ./qp-build/consume | grep -q mkl-pardiso

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,8 +31,19 @@ endif()
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
 # Disable compiler extensions for strict standard compliance.
+# Strict C99, the oldest standard a shipping consumer compiles scs with (the
+# MATLAB binding uses -std=c99): GNU-only constructs fail here first.
+set(CMAKE_C_STANDARD 99)
+set(CMAKE_C_STANDARD_REQUIRED ON)
 set(CMAKE_C_EXTENSIONS OFF)
 set(CMAKE_CXX_EXTENSIONS OFF)
+# Strict C99 hides POSIX declarations on glibc and illumos (sigaction,
+# clock_gettime, struct timespec) unless a feature-test macro asks for them.
+# A compile definition reaches every translation unit whatever its include
+# order, which a header cannot guarantee.
+if(CMAKE_SYSTEM_NAME MATCHES "Linux|SunOS")
+  add_compile_definitions(_POSIX_C_SOURCE=200809L)
+endif()
 list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
 
 option(BUILD_SHARED_LIBS "Build libraries as shared as opposed to static" ON)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,12 +1,19 @@
 # CMakeLists.txt file for scs. This software may be modified and distributed
 # under the terms of the MIT License
 
-cmake_minimum_required(VERSION 3.10)
+# 3.22: FindLAPACK honors BLA_SIZEOF_INTEGER (the LP64/ILP64 contract) and
+# provides the LAPACK::LAPACK target that keeps static packages relocatable.
+cmake_minimum_required(VERSION 3.22)
 
 project(
   scs
   LANGUAGES C
   VERSION 3.3.0)
+
+# ABI version, the loader identity of the shared libraries (libscsdir.so.3.3):
+# bump on ABI breaks, never on patch releases. scs.mk derives the same value
+# from SCS_VERSION in include/glbopts.h.
+set(SCS_ABI_VERSION "${scs_VERSION_MAJOR}.${scs_VERSION_MINOR}")
 
 # Standard GNU install directories (lib, bin, include, etc.)
 include(GNUInstallDirs)
@@ -36,7 +43,6 @@ set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 set(CMAKE_C_STANDARD 99)
 set(CMAKE_C_STANDARD_REQUIRED ON)
 set(CMAKE_C_EXTENSIONS OFF)
-set(CMAKE_CXX_EXTENSIONS OFF)
 # Strict C99 hides POSIX declarations on glibc and illumos (sigaction,
 # clock_gettime, struct timespec) unless a feature-test macro asks for them.
 # A compile definition reaches every translation unit whatever its include
@@ -44,6 +50,8 @@ set(CMAKE_CXX_EXTENSIONS OFF)
 if(CMAKE_SYSTEM_NAME MATCHES "Linux|SunOS")
   add_compile_definitions(_POSIX_C_SOURCE=200809L)
 endif()
+
+set(CMAKE_CXX_EXTENSIONS OFF)
 list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
 
 option(BUILD_SHARED_LIBS "Build libraries as shared as opposed to static" ON)
@@ -163,7 +171,10 @@ if(USE_LAPACK)
   endif()
   find_package(LAPACK)
   if(LAPACK_FOUND)
-    set(LAPACK_LINK_LIBRARIES ${LAPACK_LIBRARIES})
+    # Link the imported target, not resolved paths: a static library exports
+    # its private link line, and absolute provider paths would make the
+    # installed package usable only on this machine.
+    set(LAPACK_LINK_LIBRARIES LAPACK::LAPACK)
   else()
     if(BLAS64)
       message(FATAL_ERROR
@@ -330,7 +341,8 @@ target_link_libraries(${${PROJECT_NAME}_DIRECT}
 
 set_target_properties(
   ${${PROJECT_NAME}_DIRECT}
-  PROPERTIES VERSION ${scs_VERSION} PUBLIC_HEADER
+  PROPERTIES VERSION ${scs_VERSION} SOVERSION ${SCS_ABI_VERSION}
+             PUBLIC_HEADER
                                     "${${PROJECT_NAME}_PUBLIC_HDR}")
 
 add_library(scs::${${PROJECT_NAME}_DIRECT} ALIAS ${${PROJECT_NAME}_DIRECT})
@@ -374,7 +386,8 @@ target_link_libraries(${${PROJECT_NAME}_INDIRECT}
 
 set_target_properties(
   ${${PROJECT_NAME}_INDIRECT}
-  PROPERTIES VERSION ${scs_VERSION} PUBLIC_HEADER
+  PROPERTIES VERSION ${scs_VERSION} SOVERSION ${SCS_ABI_VERSION}
+             PUBLIC_HEADER
                                     "${${PROJECT_NAME}_PUBLIC_HDR}")
 
 add_library(scs::${${PROJECT_NAME}_INDIRECT} ALIAS ${${PROJECT_NAME}_INDIRECT})
@@ -420,7 +433,8 @@ if(USE_LAPACK)
 
   set_target_properties(
     ${${PROJECT_NAME}_DENSE}
-    PROPERTIES VERSION ${scs_VERSION} PUBLIC_HEADER
+    PROPERTIES VERSION ${scs_VERSION} SOVERSION ${SCS_ABI_VERSION}
+             PUBLIC_HEADER
                                       "${${PROJECT_NAME}_PUBLIC_HDR}")
 
   add_library(scs::${${PROJECT_NAME}_DENSE} ALIAS ${${PROJECT_NAME}_DENSE})
@@ -478,27 +492,25 @@ if(DEFINED ENV{MKLROOT})
   #
   # Note: The PARDISO integer width (pardiso vs pardiso_64) is controlled by
   # DLONG, not by the MKL interface layer. See linsys/mkl/direct/private.c.
-  target_link_options(${${PROJECT_NAME}_MKL} PRIVATE "LINKER:--no-as-needed")
-  # MKLROOT points to the MKL installation; the compiler directory (OMPROOT
-  # or fallback) contains libiomp5 (Intel OpenMP runtime).
-  if(DEFINED ENV{OMPROOT})
-    set(_OMPROOT "$ENV{OMPROOT}")
-  else()
-    set(_OMPROOT "$ENV{MKLROOT}")
-  endif()
-  target_link_directories(${${PROJECT_NAME}_MKL} PRIVATE
-    $ENV{MKLROOT}/lib $ENV{MKLROOT}/lib/intel64 ${_OMPROOT}/lib)
+  # oneMKL's own package config (MKLConfig.cmake, oneMKL >= 2021.3) provides
+  # the MKL::MKL target, which keeps a static export relocatable; SDL mode
+  # links the single dynamic library (mkl_rt) whose MKL_Set_Interface_Layer
+  # the runtime check uses. --no-as-needed keeps mkl_rt as DT_NEEDED for that
+  # check; it is a GNU/ELF option, hence Linux only.
+  set(MKL_LINK sdl)
+  find_package(MKL CONFIG REQUIRED PATHS "$ENV{MKLROOT}")
+  set(SCS_MKL_USES_CONFIG TRUE)
+  target_link_options(${${PROJECT_NAME}_MKL} PRIVATE
+                      "$<$<PLATFORM_ID:Linux>:LINKER:--no-as-needed>")
   target_link_libraries(
     ${${PROJECT_NAME}_MKL}
-    PRIVATE m
-            mkl_rt
-            iomp5
-            Threads::Threads
-            dl)
+    PRIVATE $<$<NOT:$<PLATFORM_ID:Windows>>:m> MKL::MKL Threads::Threads
+            ${CMAKE_DL_LIBS})
 
   set_target_properties(
     ${${PROJECT_NAME}_MKL}
-    PROPERTIES VERSION ${scs_VERSION} PUBLIC_HEADER
+    PROPERTIES VERSION ${scs_VERSION} SOVERSION ${SCS_ABI_VERSION}
+             PUBLIC_HEADER
                                       "${${PROJECT_NAME}_PUBLIC_HDR}")
 
   add_library(scs::${${PROJECT_NAME}_MKL} ALIAS ${${PROJECT_NAME}_MKL})
@@ -561,7 +573,8 @@ if(USE_CUDSS)
 
   set_target_properties(
     ${${PROJECT_NAME}_CUDSS}
-    PROPERTIES VERSION ${scs_VERSION} PUBLIC_HEADER
+    PROPERTIES VERSION ${scs_VERSION} SOVERSION ${SCS_ABI_VERSION}
+             PUBLIC_HEADER
                                       "${${PROJECT_NAME}_PUBLIC_HDR}")
 
   add_library(scs::${${PROJECT_NAME}_CUDSS} ALIAS ${${PROJECT_NAME}_CUDSS})
@@ -618,7 +631,8 @@ if(APPLE AND USE_APPLE_ACCELERATE)
 
   set_target_properties(
     ${${PROJECT_NAME}_ACCEL}
-    PROPERTIES VERSION ${scs_VERSION} PUBLIC_HEADER
+    PROPERTIES VERSION ${scs_VERSION} SOVERSION ${SCS_ABI_VERSION}
+             PUBLIC_HEADER
                                       "${${PROJECT_NAME}_PUBLIC_HDR}")
 
   add_library(scs::${${PROJECT_NAME}_ACCEL} ALIAS ${${PROJECT_NAME}_ACCEL})
@@ -637,6 +651,12 @@ endif()
 
 # Install CMake package config files for find_package(scs) support.
 include(InstallBasicPackageFiles)
+# The config template re-finds a static library's private dependencies at the
+# LAPACK integer width scs was built with; see cmake/scsConfig.cmake.in.
+set(SCS_LAPACK_INT_BYTES "")
+if(USE_LAPACK AND LAPACK_FOUND)
+  set(SCS_LAPACK_INT_BYTES "${BLA_SIZEOF_INTEGER}")
+endif()
 install_basic_package_files(
   ${PROJECT_NAME}
   NAMESPACE
@@ -649,6 +669,8 @@ install_basic_package_files(
   SameMajorVersion
   VARS_PREFIX
   ${PROJECT_NAME}
+  CONFIG_TEMPLATE
+  "${CMAKE_CURRENT_SOURCE_DIR}/cmake/scsConfig.cmake.in"
   NO_CHECK_REQUIRED_COMPONENTS_MACRO)
 
 # Tests

--- a/Makefile
+++ b/Makefile
@@ -124,29 +124,33 @@ $(OUT)/libscsaccel.a: $(SCS_O) $(SCS_OBJECTS) $(ACCELSRC)/private.o $(LINSYS)/sc
 	$(ARCHIVE) $@ $^
 	- $(RANLIB) $@
 
-$(OUT)/libscsdir.$(SHARED): $(SCS_O) $(SCS_OBJECTS) $(DIRSRC)/private.o $(AMD_OBJS) $(LDL_OBJS) $(LINSYS)/scs_matrix.o $(LINSYS)/csparse.o
+# Link a shared library as its versioned file with the ABI version as its
+# soname/install_name, then point the unversioned name at it (Windows: the
+# DLL itself, unversioned). $(1): extra link flags.
+V = $(call versioned,$@)
+define link_shared
 	mkdir -p $(OUT)
-	$(CC) $(CFLAGS) -shared -Wl,$(SONAME),$(@:$(OUT)/%=%) -o $@ $^ $(LDFLAGS) $(BLASLDFLAGS)
+	$(CC) $(CFLAGS) -shared -Wl,$(SONAME),$(notdir $(V)) -o $(V) $^ $(LDFLAGS) $(1)
+	[ "$(V)" = "$@" ] || ln -sf $(notdir $(V)) $@
+endef
+
+$(OUT)/libscsdir.$(SHARED): $(SCS_O) $(SCS_OBJECTS) $(DIRSRC)/private.o $(AMD_OBJS) $(LDL_OBJS) $(LINSYS)/scs_matrix.o $(LINSYS)/csparse.o
+	$(call link_shared,$(BLASLDFLAGS))
 
 $(OUT)/libscsindir.$(SHARED): $(SCS_INDIR_O) $(SCS_OBJECTS) $(INDIRSRC)/private.o $(LINSYS)/scs_matrix.o $(LINSYS)/csparse.o
-	mkdir -p $(OUT)
-	$(CC) $(CFLAGS) -shared -Wl,$(SONAME),$(@:$(OUT)/%=%) -o $@ $^ $(LDFLAGS) $(BLASLDFLAGS)
+	$(call link_shared,$(BLASLDFLAGS))
 
 $(OUT)/libscsdense.$(SHARED): $(SCS_O) $(SCS_OBJECTS) $(DENSESRC)/private.o $(LINSYS)/scs_matrix.o $(LINSYS)/csparse.o
-	mkdir -p $(OUT)
-	$(CC) $(CFLAGS) -shared -Wl,$(SONAME),$(@:$(OUT)/%=%) -o $@ $^ $(LDFLAGS) $(BLASLDFLAGS)
+	$(call link_shared,$(BLASLDFLAGS))
 
 $(OUT)/libscsmkl.$(SHARED): $(SCS_MKL_O) $(SCS_OBJECTS) $(MKLSRC)/private.o $(LINSYS)/scs_matrix.o $(LINSYS)/csparse.o
-	mkdir -p $(OUT)
-	$(CC) $(CFLAGS) -shared -Wl,$(SONAME),$(@:$(OUT)/%=%) -o $@ $^ $(LDFLAGS) $(MKLFLAGS)
+	$(call link_shared,$(MKLFLAGS))
 
 $(OUT)/libscscudss.$(SHARED): $(SCS_O) $(SCS_OBJECTS) $(CUDSSSRC)/private.o $(LINSYS)/scs_matrix.o $(LINSYS)/csparse.o
-	mkdir -p $(OUT)
-	$(CC) $(CFLAGS) -shared -Wl,$(SONAME),$(@:$(OUT)/%=%) -o $@ $^ $(LDFLAGS) $(CULDFLAGS)
+	$(call link_shared,$(CULDFLAGS))
 
 $(OUT)/libscsaccel.$(SHARED): $(SCS_O) $(SCS_OBJECTS) $(ACCELSRC)/private.o $(LINSYS)/scs_matrix.o $(LINSYS)/csparse.o
-	mkdir -p $(OUT)
-	$(CC) $(CFLAGS) -shared -Wl,$(SONAME),$(@:$(OUT)/%=%) -o $@ $^ $(LDFLAGS) -framework Accelerate
+	$(call link_shared,-framework Accelerate)
 
 $(OUT)/demo_socp_direct: test/random_socp_prob.c $(OUT)/libscsdir.a
 	$(CC) $(CFLAGS) -o $@ $^ $(LDFLAGS) $(BLASLDFLAGS)
@@ -234,8 +238,7 @@ $(GPUINDIR)/private.o: $(GPUINDIR)/private.c
 	$(CC) -c -o $@ $^ $(CUDAFLAGS)
 
 $(OUT)/libscsgpuindir.$(SHARED): $(SCS_INDIR_O) $(SCS_OBJECTS) $(GPUINDIR)/private.o $(LINSYS)/scs_matrix.o $(LINSYS)/csparse.o $(LINSYS)/gpu/gpu.o
-	mkdir -p $(OUT)
-	$(CC) $(CFLAGS) -shared -Wl,$(SONAME),$(@:$(OUT)/%=%) -o $@ $^ $(LDFLAGS) $(BLASLDFLAGS) $(CULDFLAGS)
+	$(call link_shared,$(BLASLDFLAGS) $(CULDFLAGS))
 
 $(OUT)/libscsgpuindir.a: $(SCS_INDIR_O) $(SCS_OBJECTS) $(GPUINDIR)/private.o $(LINSYS)/scs_matrix.o $(LINSYS)/csparse.o $(LINSYS)/gpu/gpu.o
 	mkdir -p $(OUT)
@@ -261,6 +264,14 @@ INSTALL_INC_FILES = $(INC_FILES)
 INSTALL_TARGETS = $(OUT)/libscsdir.a $(OUT)/libscsindir.a $(OUT)/libscsdir.$(SHARED) $(OUT)/libscsindir.$(SHARED)
 INSTALL_GPU_TARGETS = $(OUT)/libscsgpuindir.a $(OUT)/libscsgpuindir.$(SHARED)
 
+# shared libraries are installed under their versioned names with the
+# unversioned symlink alongside
+INSTALL_SHARED = $(filter %.$(SHARED),$(INSTALL_TARGETS))
+INSTALL_GPU_SHARED = $(filter %.$(SHARED),$(INSTALL_GPU_TARGETS))
+# the versioned files, plus the unversioned symlinks copied as symlinks
+install_shared = $(INSTALL) -m 644 $(call versioned,$(1)) $(INSTALL_LIB_DIR) && \
+	{ [ "$(call versioned,$(1))" = "$(1)" ] || cp -RP $(1) $(INSTALL_LIB_DIR); }
+
 INSTALL_INC_DIR = $(DESTDIR)$(PREFIX)/include/scs/
 INSTALL_LIB_DIR = $(DESTDIR)$(PREFIX)/lib/
 
@@ -271,10 +282,12 @@ dense: $(OUT)/libscsdense.a $(OUT)/libscsdense.$(SHARED) $(OUT)/run_tests_dense 
 install: $(INSTALL_INC_FILES) $(INSTALL_TARGETS)
 	$(INSTALL) -d $(INSTALL_INC_DIR) $(INSTALL_LIB_DIR)
 	$(INSTALL) -m 644 $(INSTALL_INC_FILES) $(INSTALL_INC_DIR)
-	$(INSTALL) -m 644 $(INSTALL_TARGETS) $(INSTALL_LIB_DIR)
+	$(INSTALL) -m 644 $(filter-out %.$(SHARED),$(INSTALL_TARGETS)) $(INSTALL_LIB_DIR)
+	$(call install_shared,$(INSTALL_SHARED))
 install_gpu: $(INSTALL_INC_FILES) $(INSTALL_GPU_TARGETS)
 	$(INSTALL) -d $(INSTALL_INC_DIR) $(INSTALL_LIB_DIR)
 	$(INSTALL) -m 644 $(INSTALL_INC_FILES) $(INSTALL_INC_DIR)
-	$(INSTALL) -m 644 $(INSTALL_GPU_TARGETS) $(INSTALL_LIB_DIR)
+	$(INSTALL) -m 644 $(filter-out %.$(SHARED),$(INSTALL_GPU_TARGETS)) $(INSTALL_LIB_DIR)
+	$(call install_shared,$(INSTALL_GPU_SHARED))
 direct: $(OUT)/libscsdir.$(SHARED) $(OUT)/demo_socp_direct $(OUT)/run_from_file_direct $(OUT)/run_tests_direct
 indirect: $(OUT)/libscsindir.$(SHARED) $(OUT)/demo_socp_indirect $(OUT)/run_from_file_indirect $(OUT)/run_tests_indirect

--- a/cmake/scsConfig.cmake.in
+++ b/cmake/scsConfig.cmake.in
@@ -1,0 +1,58 @@
+set(scs_VERSION @PACKAGE_VERSION@)
+
+@PACKAGE_INIT@
+
+include(CMakeFindDependencyMacro)
+
+# A static scs library exports its private link line, so a consumer must
+# re-find the same dependencies; a shared library carries them privately and
+# needs none of this.
+if(NOT @BUILD_SHARED_LIBS@)
+  find_dependency(Threads)
+  # The LAPACK integer width (LP64 or ILP64) is compiled into scs; empty
+  # when scs was built without LAPACK. A consumer that already resolved
+  # LAPACK at another width cannot link this package; one that has not is
+  # pinned to the right width here.
+  set(_scs_width "@SCS_LAPACK_INT_BYTES@")
+  if(_scs_width)
+    if(TARGET LAPACK::LAPACK
+       AND NOT "${BLA_SIZEOF_INTEGER}" STREQUAL "${_scs_width}")
+      message(
+        FATAL_ERROR
+          "scs was built with ${_scs_width}-byte LAPACK integers, but "
+          "LAPACK::LAPACK already exists in this scope with "
+          "BLA_SIZEOF_INTEGER='${BLA_SIZEOF_INTEGER}'. Set "
+          "BLA_SIZEOF_INTEGER=${_scs_width} before your own "
+          "find_package(LAPACK), or let scs find LAPACK.")
+    endif()
+    set(BLA_SIZEOF_INTEGER "${_scs_width}")
+    find_dependency(LAPACK)
+  endif()
+  if(@OpenMP_C_FOUND@)
+    find_dependency(OpenMP)
+  endif()
+  if(@SCS_MKL_USES_CONFIG@)
+    # scs links MKL's single dynamic library (mkl_rt); oneMKL's config
+    # defaults to the component libraries unless MKL_LINK says otherwise.
+    set(MKL_LINK sdl)
+    find_dependency(MKL CONFIG PATHS "$ENV{MKLROOT}")
+  endif()
+  if(@USE_CUDSS@)
+    find_dependency(CUDAToolkit)
+    find_dependency(cudss)
+  endif()
+endif()
+
+if(NOT TARGET scs::scsdir)
+  include("${CMAKE_CURRENT_LIST_DIR}/scsTargets.cmake")
+endif()
+
+# Compatibility variables
+set(scs_LIBRARIES)
+foreach(_scs_component scsdir scsindir scsdense scsaccel scsmkl scscudss)
+  if(TARGET scs::${_scs_component})
+    list(APPEND scs_LIBRARIES scs::${_scs_component})
+  endif()
+endforeach()
+get_property(scs_INCLUDE_DIRS TARGET scs::scsdir
+             PROPERTY INTERFACE_INCLUDE_DIRECTORIES)

--- a/cmake/scsConfig.cmake.in
+++ b/cmake/scsConfig.cmake.in
@@ -8,6 +8,14 @@ include(CMakeFindDependencyMacro)
 # re-find the same dependencies; a shared library carries them privately and
 # needs none of this.
 if(NOT @BUILD_SHARED_LIBS@)
+  # Older FindLAPACK versions ignore BLA_SIZEOF_INTEGER and can silently
+  # link an ILP64 archive against LP64 LAPACK.
+  if(CMAKE_VERSION VERSION_LESS 3.22)
+    set(scs_FOUND FALSE)
+    set(scs_NOT_FOUND_MESSAGE
+        "Static scs packages require CMake 3.22 or newer to enforce the LAPACK integer width.")
+    return()
+  endif()
   find_dependency(Threads)
   # The LAPACK integer width (LP64 or ILP64) is compiled into scs; empty
   # when scs was built without LAPACK. A consumer that already resolved

--- a/include/aa.h
+++ b/include/aa.h
@@ -17,7 +17,7 @@ extern "C" {
 typedef scs_float aa_float;
 typedef scs_int aa_int;
 
-typedef struct ACCEL_WORK AaWork;
+/* AaWork is declared in scs.h (included via glbopts.h) */
 
 /**
  * Initialize Anderson Acceleration, allocates memory.

--- a/scs.mk
+++ b/scs.mk
@@ -28,22 +28,33 @@ endif
 endif
 endif
 
+# ABI version embedded in the shared-library soname/install_name, derived from
+# SCS_VERSION (keep project() in CMakeLists.txt in step). Bump on ABI breaks,
+# never on patch releases.
+SCS_SOVERSION := $(shell awk -F'"' '/define SCS_VERSION/ {split($$2, v, "."); print v[1] "." v[2]}' include/glbopts.h)
+
+# versioned(name): the file a shared library is linked as; the unversioned
+# name becomes a symlink to it (libscsdir.so.3.3, libscsdir.3.3.dylib).
+# Windows DLLs stay unversioned.
 ifeq ($(UNAME), Darwin)
 # we're on apple, no need to link rt library
 LDFLAGS += -lm
 SHARED = dylib
 SONAME = -install_name
+versioned = $(1:%.dylib=%.$(SCS_SOVERSION).dylib)
 else
 ifeq ($(ISWINDOWS), 1)
 # we're on windows (cygwin or msys)
 LDFLAGS += -lm
 SHARED = dll
 SONAME = -soname
+versioned = $(1)
 else
 # we're on a linux system, use accurate timer provided by clock_gettime()
 LDFLAGS += -lm -lrt -lpthread
 SHARED = so
 SONAME = -soname
+versioned = $(1:%.so=%.so.$(SCS_SOVERSION))
 endif
 endif
 

--- a/test/packaging/CMakeLists.txt
+++ b/test/packaging/CMakeLists.txt
@@ -1,0 +1,20 @@
+# Consumes an INSTALLED scs package (see .github/workflows/cmake_consume.yml).
+cmake_minimum_required(VERSION 3.22)
+project(scs_consume C)
+
+set(SCS_COMPONENT scsdir CACHE STRING "scs library to consume (scsdir, scsmkl, ...)")
+
+# CI: a consumer that resolved LAPACK at the wrong integer width before scs
+# must be refused by a static package.
+option(PREFIND_LAPACK_WRONG_WIDTH "find LAPACK with 4-byte integers first" OFF)
+if(PREFIND_LAPACK_WRONG_WIDTH)
+  set(BLA_SIZEOF_INTEGER 4)
+  find_package(LAPACK REQUIRED)
+endif()
+
+find_package(scs CONFIG REQUIRED)
+if(NOT scs::${SCS_COMPONENT} IN_LIST scs_LIBRARIES)
+  message(FATAL_ERROR "scs_LIBRARIES=${scs_LIBRARIES} lacks scs::${SCS_COMPONENT}")
+endif()
+add_executable(consume consume.c)
+target_link_libraries(consume PRIVATE scs::${SCS_COMPONENT})

--- a/test/packaging/CMakeLists.txt
+++ b/test/packaging/CMakeLists.txt
@@ -1,5 +1,6 @@
 # Consumes an INSTALLED scs package (see .github/workflows/cmake_consume.yml).
-cmake_minimum_required(VERSION 3.22)
+# The installed package, not this fixture, must enforce its consumer floor.
+cmake_minimum_required(VERSION 3.18)
 project(scs_consume C)
 
 set(SCS_COMPONENT scsdir CACHE STRING "scs library to consume (scsdir, scsmkl, ...)")

--- a/test/packaging/consume.c
+++ b/test/packaging/consume.c
@@ -1,0 +1,50 @@
+/* Minimal consumer of an *installed* SCS package: links scs::scsdir via
+ * find_package(scs) and solves a tiny QP. Used by the cmake_consume CI
+ * workflow to prove installed packages are usable for both shared and
+ * static builds (and that shared installs demand no private build deps). */
+#include "scs.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+
+int main(void) {
+  scs_float P_x[3] = {3., -1., 2.};
+  scs_int P_i[3] = {0, 0, 1};
+  scs_int P_p[3] = {0, 1, 3};
+  scs_float A_x[4] = {-1., 1., 1., 1.};
+  scs_int A_i[4] = {0, 1, 0, 2};
+  scs_int A_p[3] = {0, 2, 4};
+  scs_float b[3] = {-1., 0.3, -0.5};
+  scs_float c[2] = {-1., -1.};
+  ScsCone k = {0};
+  ScsData d = {0};
+  ScsSettings stgs = {0};
+  ScsSolution sol = {0};
+  ScsInfo info;
+  scs_int exitflag;
+
+  printf("consuming scs %s\n", scs_version());
+
+  d.m = 3;
+  d.n = 2;
+  d.b = b;
+  d.c = c;
+  d.A = &(ScsMatrix){A_x, A_i, A_p, 3, 2};
+  d.P = &(ScsMatrix){P_x, P_i, P_p, 2, 2};
+  k.z = 1;
+  k.l = 2;
+
+  scs_set_default_settings(&stgs);
+  stgs.verbose = 1;
+
+  exitflag = scs(&d, &k, &stgs, &sol, &info);
+  if (exitflag != SCS_SOLVED) {
+    fprintf(stderr, "consume: solve failed with exitflag %d\n", (int)exitflag);
+    return 1;
+  }
+  printf("consume: solved, objective %f\n", info.pobj);
+  free(sol.x);
+  free(sol.y);
+  free(sol.s);
+  return 0;
+}


### PR DESCRIPTION
Three packaging findings from the 3.3.0 review, one commit each, plus their CI:

1. **Versioned sonames.** `ScsSettings`/`ScsInfo` grew in 3.3.0 and the unversioned soname let 3.2.11-compiled callers load 3.3.0 and corrupt memory (the review reproduced an ASan stack overflow). Make and CMake builds now embed `major.minor` (`SCS_SOVERSION`, derived from `SCS_VERSION` in `glbopts.h`; CMake `SOVERSION`), so `make install` / `cmake --install` produce `libscs*.so.3.3` (`libscs*.3.3.dylib` with a matching `install_name`) plus the unversioned dev symlink, and a mismatch fails at load time. Windows DLLs keep their names: Windows has no soname mechanism, DLLs deploy side by side, and downstream consumers (SCS_jll, ctypes users) load `libscsdir.dll` by name.
2. **Relocatable CMake package.** `scsConfig.cmake` re-finds the dependencies the exported targets reference (`Threads`, and `LAPACK`, `OpenMP`, `MKL` or `cudss` as built), so a static consumer's plain `find_package(scs)` configures; it refuses a pre-existing `LAPACK::LAPACK` of the other integer width, so a BLAS64 build cannot be linked against a 32-bit LAPACK silently.
3. **Strict C99.** `CMAKE_C_STANDARD 99` with `C_STANDARD_REQUIRED` and `C_EXTENSIONS OFF` is now in effect (it had been a no-op below CMake 3.22); the build defines `_POSIX_C_SOURCE=200809L` on Linux and SunOS for `clock_gettime`, and the duplicate `AaWork` typedef that C99 rejects is gone.

CI: `cmake_consume.yml` installs the package and builds an external consumer against it (shared and static; a BLAS64 build refusing a 32-bit LAPACK; a `-Werror` build), the MKL workflow consumes a relocated static build, and the Make jobs on Linux and macOS run `make install` and check the versioned library, the dev symlink and the soname. Push triggers are limited to master and tags with cancel-in-progress.

The generated-doc removal that used to be part of this PR is #425.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
