### PR TITLE
Pinned-regularization contract, backend OOM checks, PSD metric docs

### DIFF
--- a/docs/src/algorithm/scale.rst
+++ b/docs/src/algorithm/scale.rst
@@ -194,8 +194,13 @@ updated at scale-update events from that row's relative primal residual
                          {\max(|(Ax)_i|, |s_i|, |b_i \tau|, \epsilon_{\rm den})},
 
 by a damped multiplicative step towards the geometric mean of the profile,
-clamped to a bounded range and held constant within each non-polyhedral cone
-block (the projections require a single metric value per block). An update
+clamped to a bounded range and constrained within each non-polyhedral cone
+block to a form the cone projection can absorb: a single metric value for
+most cone types, but for real PSD blocks the richer rank-one family
+:math:`w_{ij} = \delta_i \delta_j` (a diagonal congruence
+:math:`X \to D X D`, which maps the cone to itself), fitted per block by
+least squares in log space. The PSD projection under such a metric is
+computed exactly via a congruence sandwich around the eigendecomposition. An update
 also fires when the accumulated per-row drift alone is large enough, so that
 a railed scalar :code:`scale` cannot freeze the diagonal. This is the
 dynamic analog of the row half of Ruiz equilibration, using the residuals the

--- a/linsys/accelerate/direct/private.c
+++ b/linsys/accelerate/direct/private.c
@@ -22,6 +22,10 @@ ScsLinSysWork *scs_init_lin_sys_work(const ScsMatrix *A, const ScsMatrix *P,
 
   p->diag_p = (scs_float *)scs_calloc(A->n, sizeof(scs_float));
   p->diag_r_idxs = (scs_int *)scs_calloc(n_plus_m, sizeof(scs_int));
+  if (!p->diag_p || !p->diag_r_idxs) {
+    scs_free_lin_sys_work(p);
+    return SCS_NULL;
+  }
 
   /* Form upper triangular KKT matrix in CSC format */
   p->kkt = SCS(form_kkt)(A, P, p->diag_p, diag_r, p->diag_r_idxs, 1);

--- a/linsys/mkl/direct/private.c
+++ b/linsys/mkl/direct/private.c
@@ -62,16 +62,21 @@ const char *scs_get_lin_sys_method() {
 
 void scs_free_lin_sys_work(ScsLinSysWork *p) {
   if (p) {
-    p->phase = PARDISO_CLEANUP;
-    _PARDISO(p->pt, &(p->maxfct), &(p->mnum), &(p->mtype), &(p->phase),
-             &(p->n_plus_m), SCS_NULL, p->kkt->p, p->kkt->i, SCS_NULL,
-             &(p->nrhs), p->iparm, &(p->msglvl), SCS_NULL, SCS_NULL,
-             &(p->error));
-    if (p->error != 0) {
-      scs_printf("Error during MKL Pardiso cleanup: %d", (int)p->error);
-    }
-    if (p->kkt)
+    /* Pardiso cleanup needs the KKT index arrays; on early allocation
+     * failures the workspace may be freed before the KKT matrix (or
+     * the factorization) ever existed, so gate the solver teardown on
+     * what was actually initialized. */
+    if (p->kkt) {
+      p->phase = PARDISO_CLEANUP;
+      _PARDISO(p->pt, &(p->maxfct), &(p->mnum), &(p->mtype), &(p->phase),
+               &(p->n_plus_m), SCS_NULL, p->kkt->p, p->kkt->i, SCS_NULL,
+               &(p->nrhs), p->iparm, &(p->msglvl), SCS_NULL, SCS_NULL,
+               &(p->error));
+      if (p->error != 0) {
+        scs_printf("Error during MKL Pardiso cleanup: %d", (int)p->error);
+      }
       SCS(cs_spfree)(p->kkt);
+    }
     if (p->diag_r_idxs)
       scs_free(p->diag_r_idxs);
     if (p->diag_p)

--- a/linsys/mkl/direct/private.c
+++ b/linsys/mkl/direct/private.c
@@ -92,6 +92,10 @@ ScsLinSysWork *scs_init_lin_sys_work(const ScsMatrix *A, const ScsMatrix *P,
 
   p->diag_r_idxs = (scs_int *)scs_calloc(p->n_plus_m, sizeof(scs_int));
   p->diag_p = (scs_float *)scs_calloc(p->n, sizeof(scs_float));
+  if (!p->diag_r_idxs || !p->diag_p) {
+    scs_free_lin_sys_work(p);
+    return SCS_NULL;
+  }
 
   /* MKL pardiso requires upper triangular CSR matrices. The KKT matrix stuffed
    * as CSC lower triangular is equivalent. Pass upper=0. */

--- a/src/scs.c
+++ b/src/scs.c
@@ -439,10 +439,10 @@ static scs_int validate(const ScsData *d, const ScsCone *k,
                "(use acceleration_type_1=0 for type-II AA).\n");
     return -1;
   }
-  if (!isfinite(stgs->acceleration_regularization) ||
-      stgs->acceleration_regularization < 0) {
-    scs_printf("acceleration_regularization must be a nonnegative finite "
-               "number.\n");
+  if (!isfinite(stgs->acceleration_regularization)) {
+    /* Sign-encoded modes per include/aa.h: positive = scaled by
+     * ||A||_F ||Y||_F, negative = pinned absolute value, zero = off. */
+    scs_printf("acceleration_regularization must be a finite number.\n");
     return -1;
   }
   if (!isfinite(stgs->acceleration_relaxation) ||

--- a/test/problems/test_solver_options.h
+++ b/test/problems/test_solver_options.h
@@ -281,7 +281,9 @@ static const char *test_invalid_aa_relaxation_rejected(void) {
 }
 
 /*
- * Test that NaN/negative acceleration_regularization is rejected by validate.
+ * Test the sign-encoded acceleration_regularization contract from
+ * include/aa.h: negative (pinned absolute) is a documented, accepted
+ * mode; only non-finite values are rejected by validate.
  */
 static const char *test_invalid_aa_regularization_rejected(void) {
   ScsCone *k;
@@ -296,9 +298,9 @@ static const char *test_invalid_aa_regularization_rejected(void) {
   stgs->acceleration_regularization = -1e-12;
 
   exitflag = scs(d, k, stgs, sol, &info);
-  mu_assert("test_invalid_aa_regularization_rejected: negative reg "
-            "should be SCS_FAILED",
-            exitflag == SCS_FAILED);
+  mu_assert("test_invalid_aa_regularization_rejected: negative (pinned) reg "
+            "is a documented mode and must be accepted",
+            exitflag != SCS_FAILED);
 
   _OPTS_CLEANUP();
 

--- a/test/problems/test_solver_options.h
+++ b/test/problems/test_solver_options.h
@@ -282,10 +282,11 @@ static const char *test_invalid_aa_relaxation_rejected(void) {
 
 /*
  * Test the sign-encoded acceleration_regularization contract from
- * include/aa.h: negative (pinned absolute) is a documented, accepted
- * mode; only non-finite values are rejected by validate.
+ * include/aa.h: negative means the absolute value is used as a pinned
+ * (unscaled) regularization -- a documented mode that must not merely be
+ * tolerated but must solve the problem.
  */
-static const char *test_invalid_aa_regularization_rejected(void) {
+static const char *test_pinned_negative_regularization_solves(void) {
   ScsCone *k;
   ScsData *d;
   ScsSettings *stgs;
@@ -298,22 +299,40 @@ static const char *test_invalid_aa_regularization_rejected(void) {
   stgs->acceleration_regularization = -1e-12;
 
   exitflag = scs(d, k, stgs, sol, &info);
-  mu_assert("test_invalid_aa_regularization_rejected: negative (pinned) reg "
-            "is a documented mode and must be accepted",
-            exitflag != SCS_FAILED);
+  mu_assert("test_pinned_negative_regularization_solves: pinned-negative reg "
+            "must solve the LP",
+            exitflag == SCS_SOLVED);
 
   _OPTS_CLEANUP();
+  return 0;
+}
 
-  _OPTS_SETUP(-2.0, 1.0);
-  stgs->verbose = 0;
-  stgs->acceleration_regularization = NAN;
+/*
+ * Non-finite acceleration_regularization values must be rejected by
+ * validate(); only the sign carries meaning, not NaN/inf.
+ */
+static const char *test_invalid_aa_regularization_rejected(void) {
+  scs_float bad[] = {NAN, INFINITY, -INFINITY};
+  scs_int j;
+  for (j = 0; j < 3; ++j) {
+    ScsCone *k;
+    ScsData *d;
+    ScsSettings *stgs;
+    ScsSolution *sol;
+    ScsInfo info = {0};
+    scs_int exitflag;
 
-  exitflag = scs(d, k, stgs, sol, &info);
-  mu_assert("test_invalid_aa_regularization_rejected: NaN reg "
-            "should be SCS_FAILED",
-            exitflag == SCS_FAILED);
+    _OPTS_SETUP(-2.0, 1.0);
+    stgs->verbose = 0;
+    stgs->acceleration_regularization = bad[j];
 
-  _OPTS_CLEANUP();
+    exitflag = scs(d, k, stgs, sol, &info);
+    mu_assert("test_invalid_aa_regularization_rejected: non-finite reg "
+              "should be SCS_FAILED",
+              exitflag == SCS_FAILED);
+
+    _OPTS_CLEANUP();
+  }
   return 0;
 }
 

--- a/test/run_tests.c
+++ b/test/run_tests.c
@@ -149,6 +149,7 @@ static const char *all_tests(void) {
   mu_run_test(test_aa_regularization_sweep);
   mu_run_test(test_negative_lookback_rejected);
   mu_run_test(test_invalid_aa_relaxation_rejected);
+  mu_run_test(test_pinned_negative_regularization_solves);
   mu_run_test(test_invalid_aa_regularization_rejected);
   mu_run_test(test_normalize_off);
   mu_run_test(test_normalize_roundtrip);


### PR DESCRIPTION
Batch of the remaining core findings from the 3.3.0 review:

1. **Contradictory AA regularization contract** — `include/aa.h` documents sign-encoded modes (negative = pinned absolute regularization) and `aa.c` implements them, but `validate()` rejected negative values. Resolution: honor the documented contract — finite negatives accepted, only non-finite rejected — and the options test now asserts the documented behavior.
2. **Unchecked allocations** in the accelerate and mkl direct backends: `diag_p`/`diag_r_idxs` went straight into `form_kkt` (write-to-NULL on OOM). Both now check-and-cleanup, matching the qdldl/cudss/dense backends. (Audited all backends for the pattern; these two were the only gaps.)
3. **Stale dynamic-scaling docs** — scale.rst still claimed a single metric value per non-polyhedral block; updated for the #417 rank-one PSD family.

58/58 direct and indirect. (Build note: `make` doesn't track test-header dependencies, so `test/run_tests.c` needs a touch after editing problem headers — bit me here, mentioning for posterity.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)