### PR TITLE
MKL: accept GNU-convention interface layers (compare width bit only)

### DIFF
--- a/.github/workflows/mkl_interface_mismatch.yml
+++ b/.github/workflows/mkl_interface_mismatch.yml
@@ -70,3 +70,23 @@ jobs:
         fi
         grep -q "MKL interface layer mismatch:" <<<"$output"
         grep -q "ERROR: MKL runtime initialization failed before solver setup." <<<"$output"
+
+    - name: Verify GNU interface layers are accepted and solve
+      run: |
+        # An MKL-backed NumPy that initializes MKL first leaves the layer at
+        # LP64|GNU (2) or ILP64|GNU (3); the runtime guard must accept the
+        # matching width and a full solve must succeed (#422).
+        set +e
+        output=$(./out/test_mkl_interface_mismatch gnu 2>&1)
+        status=$?
+        set -e
+        printf '%s\n' "$output"
+        if [[ $status -ne 0 ]]; then
+          echo "gnu-layer test failed with status $status"
+          exit 1
+        fi
+        grep -q "gnu-layer solve succeeded" <<<"$output"
+        if grep -q "MKL interface layer mismatch:" <<<"$output"; then
+          echo "guard fired on a compatible GNU layer"
+          exit 1
+        fi

--- a/.github/workflows/mkl_interface_mismatch.yml
+++ b/.github/workflows/mkl_interface_mismatch.yml
@@ -72,21 +72,5 @@ jobs:
         grep -q "ERROR: MKL runtime initialization failed before solver setup." <<<"$output"
 
     - name: Verify GNU interface layers are accepted and solve
-      run: |
-        # An MKL-backed NumPy that initializes MKL first leaves the layer at
-        # LP64|GNU (2) or ILP64|GNU (3); the runtime guard must accept the
-        # matching width and a full solve must succeed (#422).
-        set +e
-        output=$(./out/test_mkl_interface_mismatch gnu 2>&1)
-        status=$?
-        set -e
-        printf '%s\n' "$output"
-        if [[ $status -ne 0 ]]; then
-          echo "gnu-layer test failed with status $status"
-          exit 1
-        fi
-        grep -q "gnu-layer solve succeeded" <<<"$output"
-        if grep -q "MKL interface layer mismatch:" <<<"$output"; then
-          echo "guard fired on a compatible GNU layer"
-          exit 1
-        fi
+      # exits 0 only if the guard accepted the layer and the solve succeeded
+      run: ./out/test_mkl_interface_mismatch gnu

--- a/src/scs.c
+++ b/src/scs.c
@@ -30,7 +30,16 @@
  * or 3 (ILP64|GNU) -- e.g. when an MKL-backed NumPy initialized MKL
  * first. Only the width bit affects integer-size safety. */
 #define MKL_INTERFACE_GNU 2
+/* bit 0 of the layer value selects the integer width (LP64/ILP64) */
+#define MKL_INTERFACE_WIDTH_MASK MKL_INTERFACE_ILP64
+/* Only libmkl_rt provides this; a static MKL link has nothing to negotiate,
+ * so the reference is weak and the check is skipped when the symbol is
+ * absent (MSVC links mkl_rt dynamically and keeps the strong reference). */
+#if defined(__GNUC__)
+int MKL_Set_Interface_Layer(int) __attribute__((weak));
+#else
 int MKL_Set_Interface_Layer(int);
+#endif
 
 static const char *scs_mkl_interface_name(int layer) {
   switch (layer) {
@@ -66,7 +75,14 @@ static scs_int scs_init_mkl_runtime(void) {
 #else
     int expected = MKL_INTERFACE_LP64;
 #endif
-    int actual = MKL_Set_Interface_Layer(expected);
+    int actual;
+#if defined(__GNUC__)
+    if (!MKL_Set_Interface_Layer) {
+      /* static MKL: no runtime interface layer exists to query */
+      return 0;
+    }
+#endif
+    actual = MKL_Set_Interface_Layer(expected);
     /* MKL returns -1 for an invalid request; without this guard the width
      * comparison below would misread it ((-1 & 1) == 1, i.e. ILP64) */
     if (actual < 0) {
@@ -76,7 +92,8 @@ static scs_int scs_init_mkl_runtime(void) {
     }
     /* compare only the integer-width bit: the GNU flag is a Fortran
      * calling-convention variant with the same integer sizes */
-    if ((actual & MKL_INTERFACE_ILP64) != (expected & MKL_INTERFACE_ILP64)) {
+    if ((actual & MKL_INTERFACE_WIDTH_MASK) !=
+        (expected & MKL_INTERFACE_WIDTH_MASK)) {
       scs_printf("MKL interface layer mismatch: expected %s, but MKL is using "
                  "%s (%d). Another library in this process likely "
                  "initialized MKL with an incompatible LP64/ILP64 setting.\n",

--- a/src/scs.c
+++ b/src/scs.c
@@ -24,6 +24,12 @@
 #ifdef SCS_MKL
 #define MKL_INTERFACE_LP64 0
 #define MKL_INTERFACE_ILP64 1
+/* MKL's interface-layer value is a bitmask: bit 0 selects the integer
+ * width (LP64/ILP64) and bit 1 is the GNU Fortran calling-convention
+ * flag, so MKL_Set_Interface_Layer can legitimately return 2 (LP64|GNU)
+ * or 3 (ILP64|GNU) -- e.g. when an MKL-backed NumPy initialized MKL
+ * first. Only the width bit affects integer-size safety. */
+#define MKL_INTERFACE_GNU 2
 int MKL_Set_Interface_Layer(int);
 
 static const char *scs_mkl_interface_name(int layer) {
@@ -32,6 +38,10 @@ static const char *scs_mkl_interface_name(int layer) {
     return "LP64";
   case MKL_INTERFACE_ILP64:
     return "ILP64";
+  case MKL_INTERFACE_LP64 | MKL_INTERFACE_GNU:
+    return "LP64 (GNU)";
+  case MKL_INTERFACE_ILP64 | MKL_INTERFACE_GNU:
+    return "ILP64 (GNU)";
   default:
     return "unknown";
   }
@@ -57,7 +67,9 @@ static scs_int scs_init_mkl_runtime(void) {
     int expected = MKL_INTERFACE_LP64;
 #endif
     int actual = MKL_Set_Interface_Layer(expected);
-    if (actual != expected) {
+    /* compare only the integer-width bit: the GNU flag is a Fortran
+     * calling-convention variant with the same integer sizes */
+    if ((actual & MKL_INTERFACE_ILP64) != (expected & MKL_INTERFACE_ILP64)) {
       scs_printf("MKL interface layer mismatch: expected %s, but MKL is using "
                  "%s (%d). Another library in this process likely "
                  "initialized MKL with an incompatible LP64/ILP64 setting.\n",

--- a/src/scs.c
+++ b/src/scs.c
@@ -67,6 +67,13 @@ static scs_int scs_init_mkl_runtime(void) {
     int expected = MKL_INTERFACE_LP64;
 #endif
     int actual = MKL_Set_Interface_Layer(expected);
+    /* MKL returns -1 for an invalid request; without this guard the width
+     * comparison below would misread it ((-1 & 1) == 1, i.e. ILP64) */
+    if (actual < 0) {
+      scs_printf("MKL_Set_Interface_Layer(%d) failed with error %d.\n",
+                 expected, actual);
+      return -1;
+    }
     /* compare only the integer-width bit: the GNU flag is a Fortran
      * calling-convention variant with the same integer sizes */
     if ((actual & MKL_INTERFACE_ILP64) != (expected & MKL_INTERFACE_ILP64)) {

--- a/test/mkl_interface_mismatch.c
+++ b/test/mkl_interface_mismatch.c
@@ -2,13 +2,26 @@
 
 #include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
+
+/* Two modes, selected by argv[1]:
+ *
+ *   mismatch (default): preset the WRONG integer width before scs_init;
+ *     initialization must fail fast with the interface-layer diagnostic.
+ *
+ *   gnu: preset the GNU Fortran calling-convention flag together with the
+ *     CORRECT integer width (values 2 = LP64|GNU or 3 = ILP64|GNU, as an
+ *     MKL-backed NumPy does when it initializes MKL first); initialization
+ *     and a full solve must succeed, proving the runtime guard compares
+ *     only the width bit. */
 
 #define MKL_INTERFACE_LP64 0
 #define MKL_INTERFACE_ILP64 1
+#define MKL_INTERFACE_GNU 2
 
 int MKL_Set_Interface_Layer(int);
 
-int main(void) {
+int main(int argc, char **argv) {
   scs_float P_x[3] = {3., -1., 2.};
   scs_int P_i[3] = {0, 0, 1};
   scs_int P_p[3] = {0, 1, 3};
@@ -20,21 +33,27 @@ int main(void) {
   ScsCone k = {0};
   ScsData d = {0};
   ScsSettings stgs = {0};
+  ScsSolution sol = {0};
+  ScsInfo info;
   ScsWork *w;
-  int wrong_layer;
+  int gnu_mode = argc > 1 && strcmp(argv[1], "gnu") == 0;
+  int layer;
   int actual;
+  scs_int exitflag;
 
 #ifdef BLAS64
-  wrong_layer = MKL_INTERFACE_LP64;
+  layer = gnu_mode ? (MKL_INTERFACE_ILP64 | MKL_INTERFACE_GNU)
+                   : MKL_INTERFACE_LP64;
 #else
-  wrong_layer = MKL_INTERFACE_ILP64;
+  layer = gnu_mode ? (MKL_INTERFACE_LP64 | MKL_INTERFACE_GNU)
+                   : MKL_INTERFACE_ILP64;
 #endif
 
-  actual = MKL_Set_Interface_Layer(wrong_layer);
-  if (actual != wrong_layer) {
+  actual = MKL_Set_Interface_Layer(layer);
+  if (actual != layer) {
     fprintf(stderr,
             "failed to pre-set MKL interface layer to %d, actual layer is %d\n",
-            wrong_layer, actual);
+            layer, actual);
     return 2;
   }
 
@@ -50,6 +69,20 @@ int main(void) {
 
   scs_set_default_settings(&stgs);
   stgs.verbose = 1;
+
+  if (gnu_mode) {
+    exitflag = scs(&d, &k, &stgs, &sol, &info);
+    if (exitflag != SCS_SOLVED) {
+      fprintf(stderr, "gnu-layer solve failed with exitflag %d\n",
+              (int)exitflag);
+      return 4;
+    }
+    printf("gnu-layer solve succeeded (layer %d)\n", layer);
+    free(sol.x);
+    free(sol.y);
+    free(sol.s);
+    return 0;
+  }
 
   w = scs_init(&d, &k, &stgs);
   if (w != SCS_NULL) {


### PR DESCRIPTION
The MKL interface-layer guard (#383) treated `MKL_Set_Interface_Layer`'s return as an enum, but it is a bitmask: bit 0 = LP64/ILP64 width, bit 1 = GNU Fortran calling convention. When an MKL-backed NumPy initializes MKL first, the layer legitimately reads 2 (LP64|GNU) — same integer width, different Fortran name mangling — and the equality check classified it "unknown" and refused to initialize. **Every MKL solve in scs-python's conda/pixi CI failed with `ScsWork allocation error`** (invisible until bodono/scs-python#230 made that CI fail-fast; diagnosed from the captured init message).

Fix: compare only the width bit — the only property the guard exists to protect — and name the GNU variants in the diagnostic. The genuine mismatch case (LP64-linked build meeting ILP64-initialized MKL) still hard-fails exactly as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)