### PR TITLE
docs: the MKL Pardiso backend ships in the x86-64 manylinux wheels

### DIFF
--- a/docs/src/api/python.rst
+++ b/docs/src/api/python.rst
@@ -51,8 +51,8 @@ The default is :code:`AUTO`, which selects the best available solver for
 the platform:
 
 - **macOS**: QDLDL (Apple Accelerate is available via :code:`LinearSolver.ACCELERATE`)
-- **Linux / Windows**: MKL Pardiso if available (on x86-64 Linux install it
-  with :code:`pip install "scs[mkl]"` — recommended), otherwise QDLDL
+- **Linux / Windows**: MKL Pardiso if available (built into the x86-64 Linux
+  wheels), otherwise QDLDL
 
 .. list-table::
    :header-rows: 1
@@ -66,8 +66,8 @@ the platform:
    * - :code:`CPU_INDIRECT`
      - Sparse indirect solver using conjugate gradients (runs on CPU).
    * - :code:`MKL`
-     - Intel MKL Pardiso direct solver (install via :code:`pip install "scs[mkl]"`
-       on x86-64 Linux, or an :ref:`MKL build <python_install>`).
+     - Intel MKL Pardiso direct solver (built into the x86-64 Linux wheels,
+       or an :ref:`MKL build <python_install>`).
    * - :code:`ACCELERATE`
      - Apple Accelerate sparse LDL\ :sup:`T` (macOS only, included automatically).
    * - :code:`CPU_DENSE`

--- a/docs/src/api/python.rst
+++ b/docs/src/api/python.rst
@@ -51,8 +51,8 @@ The default is :code:`AUTO`, which selects the best available solver for
 the platform:
 
 - **macOS**: QDLDL (Apple Accelerate is available via :code:`LinearSolver.ACCELERATE`)
-- **Linux / Windows**: MKL Pardiso if available (built into the x86-64 Linux
-  wheels), otherwise QDLDL
+- **Linux / Windows**: MKL Pardiso if available (built into the x86-64
+  manylinux wheels), otherwise QDLDL
 
 .. list-table::
    :header-rows: 1
@@ -66,7 +66,7 @@ the platform:
    * - :code:`CPU_INDIRECT`
      - Sparse indirect solver using conjugate gradients (runs on CPU).
    * - :code:`MKL`
-     - Intel MKL Pardiso direct solver (built into the x86-64 Linux wheels,
+     - Intel MKL Pardiso direct solver (built into the x86-64 manylinux wheels,
        or an :ref:`MKL build <python_install>`).
    * - :code:`ACCELERATE`
      - Apple Accelerate sparse LDL\ :sup:`T` (macOS only, included automatically).

--- a/docs/src/api/python.rst
+++ b/docs/src/api/python.rst
@@ -51,7 +51,8 @@ The default is :code:`AUTO`, which selects the best available solver for
 the platform:
 
 - **macOS**: QDLDL (Apple Accelerate is available via :code:`LinearSolver.ACCELERATE`)
-- **Linux / Windows**: MKL Pardiso if available, otherwise QDLDL
+- **Linux / Windows**: MKL Pardiso if available (on x86-64 Linux install it
+  with :code:`pip install "scs[mkl]"` — recommended), otherwise QDLDL
 
 .. list-table::
    :header-rows: 1
@@ -65,7 +66,8 @@ the platform:
    * - :code:`CPU_INDIRECT`
      - Sparse indirect solver using conjugate gradients (runs on CPU).
    * - :code:`MKL`
-     - Intel MKL Pardiso direct solver (requires :ref:`MKL build <python_install>`).
+     - Intel MKL Pardiso direct solver (install via :code:`pip install "scs[mkl]"`
+       on x86-64 Linux, or an :ref:`MKL build <python_install>`).
    * - :code:`ACCELERATE`
      - Apple Accelerate sparse LDL\ :sup:`T` (macOS only, included automatically).
    * - :code:`CPU_DENSE`

--- a/docs/src/install/python.rst
+++ b/docs/src/install/python.rst
@@ -9,6 +9,22 @@ The easiest way to install the python version is using `pip <https://pypi.org/pr
 
   pip install scs
 
+.. important::
+
+   On x86-64 Linux we strongly recommend installing with the MKL extra:
+
+   .. code:: bash
+
+     pip install "scs[mkl]"
+
+   This enables the :ref:`MKL Pardiso <mkl>` direct linear solver, which is
+   faster than the built-in solver for most problems — often dramatically so
+   on larger ones. SCS selects it automatically when it is installed; no code
+   or settings changes are needed. The MKL runtime is supplied by Intel's
+   official ``mkl`` wheels (roughly an extra 240 MB on disk). A plain
+   ``pip install scs`` works everywhere and falls back to the built-in
+   QDLDL solver.
+
 You can also install directly from source
 
 .. code:: bash
@@ -46,21 +62,35 @@ bundled QDLDL on macOS; opt in to Accelerate explicitly with
 MKL
 """
 
-The pre-built wheels (:code:`pip install scs`) include MKL on x86_64 Linux and
-Windows. When installing from source, you can enable MKL with:
+On x86-64 Linux the pre-built wheels support the MKL Pardiso solver through
+the ``mkl`` extra — this is the recommended way to install SCS there:
+
+.. code:: bash
+
+  pip install "scs[mkl]"
+
+The MKL runtime comes from Intel's official ``mkl`` and ``intel-openmp``
+wheels (threaded MKL). SCS deliberately does not copy MKL into its own
+wheels: MKL loads its CPU dispatch kernels at runtime via ``dlopen``, which
+wheel auditing tools cannot see, so a bundled MKL is silently incomplete and
+aborts the process at solve time (see `issue #423
+<https://github.com/cvxgrp/scs/issues/423>`_). With the extra installed the
+default :code:`linear_solver=scs.LinearSolver.AUTO` selects MKL
+automatically; without it SCS falls back to the built-in QDLDL solver. MKL
+is typically faster than QDLDL.
+
+If your environment already provides MKL (e.g. conda), you can instead build
+from source against it:
 
 .. code:: bash
 
   python -m pip install -Csetup-args=-Dlink_mkl=true .
 
-When using the default :code:`linear_solver=scs.LinearSolver.AUTO`, MKL is
-selected automatically on Linux and Windows if available. MKL is
-typically faster than the built-in QDLDL linear system solver.
+See :ref:`here <python_interface>` for how to select MKL when solving.
 
-The published Linux x86_64 wheels prefer the threaded MKL variant and include
-the Intel OpenMP runtime (:code:`libiomp5`). Windows currently falls back to
-sequential MKL until Intel fixes the threaded :code:`pkg-config` metadata in
-its conda packages.
+The Windows wheels do not currently include the MKL backend; on Windows MKL
+is available in source builds, which use sequential MKL until Intel fixes
+the threaded :code:`pkg-config` metadata in its conda packages.
 
 To use 64-bit BLAS/LAPACK integers (ILP64 / :code:`BLAS64`) with any supported
 BLAS/LAPACK library, install with:

--- a/docs/src/install/python.rst
+++ b/docs/src/install/python.rst
@@ -100,17 +100,19 @@ The Windows wheels do not currently include the MKL backend; on Windows MKL
 is available in source builds, which use sequential MKL until Intel fixes
 the threaded :code:`pkg-config` metadata in its conda packages.
 
-To use 64-bit BLAS/LAPACK integers (ILP64 / :code:`BLAS64`) with any supported
-BLAS/LAPACK library, install with:
+To use 64-bit BLAS/LAPACK integers (ILP64 / :code:`BLAS64`), install with:
 
 .. code:: bash
 
-  python -m pip install -Csetup-args=-Duse_blas64=true .
+  python -m pip install -Csetup-args=-Duse_blas64=true -Csetup-args=-Dlink_mkl=true .
 
-If you combine :code:`BLAS64` with the MKL Pardiso backend, SCS requires
-64-bit SCS integers as well (the default in the Meson build). At runtime SCS
-also checks that the process-wide MKL interface layer matches the LP64/ILP64
-mode it was compiled for, and fails early if another library already set an
+The Meson build only supports :code:`BLAS64` together with MKL
+(:code:`-Dlink_mkl=true`): ILP64 variants of other BLAS libraries cannot be
+verified at build time, and 64-bit prototypes against an LP64 library
+corrupt every BLAS call. SCS then requires 64-bit SCS integers as well (the
+default in the Meson build). At runtime SCS also checks that the
+process-wide MKL interface layer matches the LP64/ILP64 mode it was
+compiled for, and fails early if another library already set an
 incompatible MKL interface.
 
 Dense direct (LAPACK)

--- a/docs/src/install/python.rst
+++ b/docs/src/install/python.rst
@@ -11,7 +11,8 @@ The easiest way to install the python version is using `pip <https://pypi.org/pr
 
 .. important::
 
-   On x86-64 Linux we strongly recommend installing with the MKL extra:
+   On x86-64 Linux (manylinux, glibc 2.28+) we strongly recommend installing
+   with the MKL extra:
 
    .. code:: bash
 
@@ -21,9 +22,9 @@ The easiest way to install the python version is using `pip <https://pypi.org/pr
    faster than the built-in solver for most problems — often dramatically so
    on larger ones. SCS selects it automatically when it is installed; no code
    or settings changes are needed. The MKL runtime is supplied by Intel's
-   official ``mkl`` wheels (roughly an extra 240 MB on disk). A plain
-   ``pip install scs`` works everywhere and falls back to the built-in
-   QDLDL solver.
+   official ``mkl`` wheels (roughly a 300 MB download, about 1 GB on disk).
+   A plain ``pip install scs`` works everywhere and falls back to the
+   built-in QDLDL solver.
 
 You can also install directly from source
 
@@ -62,8 +63,9 @@ bundled QDLDL on macOS; opt in to Accelerate explicitly with
 MKL
 """
 
-On x86-64 Linux the pre-built wheels support the MKL Pardiso solver through
-the ``mkl`` extra — this is the recommended way to install SCS there:
+On x86-64 Linux the pre-built manylinux wheels support the MKL Pardiso
+solver through the ``mkl`` extra — this is the recommended way to install
+SCS there:
 
 .. code:: bash
 
@@ -78,6 +80,12 @@ aborts the process at solve time (see `issue #423
 default :code:`linear_solver=scs.LinearSolver.AUTO` selects MKL
 automatically; without it SCS falls back to the built-in QDLDL solver. MKL
 is typically faster than QDLDL.
+
+The extra requires Intel's runtime wheels, which exist only for manylinux
+x86-64 with glibc 2.28 or newer: it is not available on musllinux/Alpine or
+older glibc systems, does not work with ``pip install --target`` layouts,
+and does not apply to sdist/source builds (build against your own MKL with
+``-Dlink_mkl=true`` instead, e.g. in conda environments).
 
 If your environment already provides MKL (e.g. conda), you can instead build
 from source against it:

--- a/docs/src/install/python.rst
+++ b/docs/src/install/python.rst
@@ -11,7 +11,7 @@ The easiest way to install the python version is using `pip <https://pypi.org/pr
 
 .. important::
 
-   On x86-64 Linux the pre-built wheels include the :ref:`MKL Pardiso <mkl>`
+   On x86-64 Linux the pre-built manylinux (glibc) wheels include the :ref:`MKL Pardiso <mkl>`
    direct linear solver, linked statically, and SCS selects it
    automatically: it is faster than the built-in solver for most problems,
    often dramatically so on larger ones, and nothing extra needs to be

--- a/docs/src/install/python.rst
+++ b/docs/src/install/python.rst
@@ -11,20 +11,11 @@ The easiest way to install the python version is using `pip <https://pypi.org/pr
 
 .. important::
 
-   On x86-64 Linux (manylinux, glibc 2.28+) we strongly recommend installing
-   with the MKL extra:
-
-   .. code:: bash
-
-     pip install "scs[mkl]"
-
-   This enables the :ref:`MKL Pardiso <mkl>` direct linear solver, which is
-   faster than the built-in solver for most problems — often dramatically so
-   on larger ones. SCS selects it automatically when it is installed; no code
-   or settings changes are needed. The MKL runtime is supplied by Intel's
-   official ``mkl`` wheels (roughly a 300 MB download, about 1 GB on disk).
-   A plain ``pip install scs`` works everywhere and falls back to the
-   built-in QDLDL solver.
+   On x86-64 Linux the pre-built wheels include the :ref:`MKL Pardiso <mkl>`
+   direct linear solver, linked statically, and SCS selects it
+   automatically: it is faster than the built-in solver for most problems,
+   often dramatically so on larger ones, and nothing extra needs to be
+   installed. Every other wheel falls back to the built-in QDLDL solver.
 
 You can also install directly from source
 
@@ -63,29 +54,19 @@ bundled QDLDL on macOS; opt in to Accelerate explicitly with
 MKL
 """
 
-On x86-64 Linux the pre-built manylinux wheels support the MKL Pardiso
-solver through the ``mkl`` extra — this is the recommended way to install
-SCS there:
+On x86-64 Linux the pre-built manylinux wheels include the MKL Pardiso
+solver: MKL is linked statically into the ``_scs_mkl`` extension, with the
+sequential threading layer and its symbols hidden, so the wheel is
+self-contained and the default
+:code:`linear_solver=scs.LinearSolver.AUTO` selects MKL with nothing else
+installed. MKL is typically faster than QDLDL.
 
-.. code:: bash
-
-  pip install "scs[mkl]"
-
-The MKL runtime comes from Intel's official ``mkl`` and ``intel-openmp``
-wheels (threaded MKL). SCS deliberately does not copy MKL into its own
-wheels: MKL loads its CPU dispatch kernels at runtime via ``dlopen``, which
-wheel auditing tools cannot see, so a bundled MKL is silently incomplete and
-aborts the process at solve time (see `issue #423
-<https://github.com/cvxgrp/scs/issues/423>`_). With the extra installed the
-default :code:`linear_solver=scs.LinearSolver.AUTO` selects MKL
-automatically; without it SCS falls back to the built-in QDLDL solver. MKL
-is typically faster than QDLDL.
-
-The extra requires Intel's runtime wheels, which exist only for manylinux
-x86-64 with glibc 2.28 or newer: it is not available on musllinux/Alpine or
-older glibc systems, does not work with ``pip install --target`` layouts,
-and does not apply to sdist/source builds (build against your own MKL with
-``-Dlink_mkl=true`` instead, e.g. in conda environments).
+MKL is linked statically rather than bundled as shared libraries, whose
+dlopen'd CPU dispatch kernels wheel-repair tools cannot see (see `issue #423
+<https://github.com/cvxgrp/scs/issues/423>`_); the backend is
+single-threaded, and Intel's license notice ships in the wheel as
+``LICENSE-INTEL-MKL.txt``. The aarch64, musllinux, macOS and Windows wheels
+and sdist/source builds do not include it.
 
 If your environment already provides MKL (e.g. conda), you can instead build
 from source against it:

--- a/docs/src/linear_solver/index.rst
+++ b/docs/src/linear_solver/index.rst
@@ -82,9 +82,8 @@ your system then it is generally worth using MKL for both the blas / lapack
 usage as well as the linear system solve.
 Intel MKL is now available for
 `free and without restrictions for everyone <https://www.intel.com/content/www/us/en/developer/articles/news/free-ipsxe-tools-and-libraries.html>`_,
-though it only offers limited support for non-Intel CPUs. For the Python
-interface on x86-64 Linux, :code:`pip install "scs[mkl]"` is all that is
-needed (see :ref:`python_install`).
+though it only offers limited support for non-Intel CPUs. The Python wheels
+for x86-64 Linux include it, statically linked (see :ref:`python_install`).
 
 .. _apple_accelerate:
 

--- a/docs/src/linear_solver/index.rst
+++ b/docs/src/linear_solver/index.rst
@@ -82,7 +82,9 @@ your system then it is generally worth using MKL for both the blas / lapack
 usage as well as the linear system solve.
 Intel MKL is now available for
 `free and without restrictions for everyone <https://www.intel.com/content/www/us/en/developer/articles/news/free-ipsxe-tools-and-libraries.html>`_,
-though it only offers limited support for non-Intel CPUs.
+though it only offers limited support for non-Intel CPUs. For the Python
+interface on x86-64 Linux, :code:`pip install "scs[mkl]"` is all that is
+needed (see :ref:`python_install`).
 
 .. _apple_accelerate:
 

--- a/docs/src/linear_solver/index.rst
+++ b/docs/src/linear_solver/index.rst
@@ -82,8 +82,8 @@ your system then it is generally worth using MKL for both the blas / lapack
 usage as well as the linear system solve.
 Intel MKL is now available for
 `free and without restrictions for everyone <https://www.intel.com/content/www/us/en/developer/articles/news/free-ipsxe-tools-and-libraries.html>`_,
-though it only offers limited support for non-Intel CPUs. The Python wheels
-for x86-64 Linux include it, statically linked (see :ref:`python_install`).
+though it only offers limited support for non-Intel CPUs. The x86-64 manylinux
+Python wheels include it, statically linked (see :ref:`python_install`).
 
 .. _apple_accelerate:
 


### PR DESCRIPTION
Companion to bodono/scs-python#232 (the #423 fix). The Python install docs still described the 3.3.0 wheel model, a dynamic MKL vendored into the wheels. Now:

- The Python install page says up front that the x86-64 manylinux (glibc) wheels include MKL Pardiso, linked statically and single-threaded, that `AUTO` selects it with nothing else installed, and that every other wheel (musllinux, aarch64, macOS, Windows) falls back to QDLDL. Intel's license notice ships in the wheel as `LICENSE-INTEL-MKL.txt`.
- The MKL section explains why MKL is linked statically rather than bundled (its dlopen'd CPU dispatch kernels are invisible to wheel repair, #423) and keeps the conda/source `-Dlink_mkl=true` instructions.
- The linear-solver page and the Python API backend table state the same facts.

Merge after bodono/scs-python#232 ships the wheels this describes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
