### PR TITLE
Bump version to 3.3.1

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 3.3.0
+current_version = 3.3.1
 
 [bumpversion:file:README.md]
 

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -10,8 +10,8 @@ authors:
 - family-names: "Boyd"
   given-names: "Stephen"
 title: "SCS: Splitting Conic Solver"
-version: 3.3.0
-date-released: 2023
+version: 3.3.1
+date-released: '2026-09-05'
 url: "https://github.com/cvxgrp/scs"
 
 # Original SCS paper:
@@ -36,4 +36,3 @@ preferred-citation:
   year: 2016
   doi: 10.1007/s10957-016-0892-3
   url: https://dx.doi.org/10.1007/s10957-016-0892-3
-

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,7 @@ cmake_minimum_required(VERSION 3.22)
 project(
   scs
   LANGUAGES C
-  VERSION 3.3.0)
+  VERSION 3.3.1)
 
 # ABI version, the loader identity of the shared libraries (libscsdir.so.3.3):
 # bump on ABI breaks, never on patch releases. scs.mk derives the same value

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/scs.svg?label=Conda%20downloads)](https://anaconda.org/conda-forge/scs)
 
 SCS (`splitting conic solver`) is a numerical optimization package for solving
-large-scale convex cone problems. The current version is `3.3.0`.
+large-scale convex cone problems. The current version is `3.3.1`.
 
 The full documentation is available [here](https://www.cvxgrp.org/scs/).
 

--- a/docs/src/Doxyfile
+++ b/docs/src/Doxyfile
@@ -38,7 +38,7 @@ PROJECT_NAME           = "SCS"
 # could be handy for archiving the generated documentation or if some version
 # control system is used.
 
-PROJECT_NUMBER         = 3.3.0
+PROJECT_NUMBER         = 3.3.1
 
 # Using the PROJECT_BRIEF tag one can provide an optional one line description
 # for a project that appears at the top of each page and should give viewer a

--- a/docs/src/citing/index.rst
+++ b/docs/src/citing/index.rst
@@ -48,10 +48,10 @@ If you wish to cite SCS, please use any of the following:
 
         @misc{scs,
             author       = {Brendan O'Donoghue and Eric Chu and Neal Parikh and Stephen Boyd},
-            title        = {{SCS}: Splitting Conic Solver, version 3.3.0},
+            title        = {{SCS}: Splitting Conic Solver, version 3.3.1},
             howpublished = {\url{https://github.com/cvxgrp/scs}},
-            month        = nov,
-            year         = 2023
+            month        = sep,
+            year         = 2026
         }
 
   Anderson Acceleration
@@ -68,4 +68,3 @@ If you wish to cite SCS, please use any of the following:
           pages={3170--3197},
           year={2020}
         }
-

--- a/docs/src/conf.py
+++ b/docs/src/conf.py
@@ -24,7 +24,7 @@ copyright = "2021, Brendan O'Donoghue"
 author = "Brendan O'Donoghue"
 
 # The full version, including alpha/beta/rc tags
-__version__ = "3.3.0"
+__version__ = "3.3.1"
 
 release = __version__
 version = __version__

--- a/include/glbopts.h
+++ b/include/glbopts.h
@@ -23,7 +23,7 @@ extern "C" {
 
 /* SCS VERSION NUMBER ----------------------------------------------     */
 /* string literals automatically null-terminated */
-#define SCS_VERSION ("3.3.0")
+#define SCS_VERSION ("3.3.1")
 
 /* verbosity level */
 #ifndef VERBOSITY


### PR DESCRIPTION
## Summary

- Bump the core library and documentation from 3.3.0 to 3.3.1 across all files listed in `.bumpversion.cfg`.
- Update the software citation date to September 2026.
- Preserve the major.minor ABI identity (`3.3`); this patch release does not change SONAME/install-name expectations.

This follows the merged and green feature/fix PRs. The Python and MATLAB release PRs will pin this PR's final merged core commit. Tags and publication remain gated on the version PRs and merged-branch CI.

## Validation

- Direct solver suite: all 60 tests passed.
- Indirect solver suite: all 60 tests passed.
- CMake shared build, installation, and external `find_package(scs)` consumer: passed; runtime reports 3.3.1 and solves successfully.
- macOS library identity is `@rpath/libscsdir.3.3.dylib`, with `libscsdir.dylib -> libscsdir.3.3.dylib -> libscsdir.3.3.1.dylib` verified.
- `git diff --check`: passed.
