### PR TITLE
Fix CUDA compiler default when CUDA_PATH is supplied

### DIFF
--- a/.github/workflows/gpu.yml
+++ b/.github/workflows/gpu.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Make cudss target
         run: |
           export CUDSS_PATH=/usr/lib/cudss
-          export CUCC=${CUDA_PATH}/bin/nvcc
-          ${CUCC} --version
-          make cudss
+          unset CUCC
+          "${CUDA_PATH}/bin/nvcc" --version
+          make cudss CUDA_PATH="${CUDA_PATH}"
       # - run: out/run_tests_cudss           # gpus not available yet

--- a/scs.mk
+++ b/scs.mk
@@ -61,6 +61,10 @@ endif
 # Default CUDA path; override with CUDA_PATH=/path/to/cuda
 ifeq ($(CUDA_PATH), )
 CUDA_PATH=/usr/local/cuda
+endif
+
+# Default the compiler independently, including when CUDA_PATH is supplied.
+ifeq ($(CUCC), )
 CUCC = $(CUDA_PATH)/bin/nvcc
 endif
 


### PR DESCRIPTION
## Summary

Default CUCC independently of CUDA_PATH. Previously, supplying CUDA_PATH without CUCC left the compiler empty and broke cuDSS builds. Explicit compiler overrides remain respected.

Update the existing GPU CI job to build cuDSS with CUDA_PATH explicitly supplied and CUCC unset, covering the regression.

## Validation

- Six make-variable checks passed: default path, environment/command-line CUDA_PATH, and environment/command-line CUCC overrides.
- Built on DGX Spark (GB10, CUDA 13.0, cuDSS 0.8) with CUDA_PATH supplied and CUCC unset.
- All 68 cuDSS core tests passed with spectral cones enabled, using OpenBLAS 0.3.34 and no kernel override.

Independent of the separate missing-string.h fix; either PR can merge first.