### PR TITLE
Include string.h for the GPU indirect memset call

### DIFF
--- a/.github/workflows/gpu.yml
+++ b/.github/workflows/gpu.yml
@@ -17,7 +17,7 @@ jobs:
           method: network
           non-cuda-sub-packages: '["libcublas", "libcusparse", "libcudart"]'
       - run: sudo apt-get install libopenblas-dev liblapack-dev
-      - run: make gpu
+      - run: CFLAGS=-Werror=implicit-function-declaration make gpu
       - run: make test_gpu
       # - run: out/run_tests_gpu_indirect    # gpus not available yet
       - name: Install cudss

--- a/linsys/gpu/indirect/private.c
+++ b/linsys/gpu/indirect/private.c
@@ -1,6 +1,8 @@
 #include "private.h"
 #include "linsys.h"
 
+#include <string.h>
+
 /* norm to use when deciding convergence */
 /* should be consistent with CG_NORM in glbopts.h */
 #define USE_L2_NORM (0)


### PR DESCRIPTION
## Summary

Include string.h directly in the GPU-indirect implementation, which calls memset. This avoids an implicit function declaration and build failures with stricter compilers.

Make the existing GPU CI build treat implicit function declarations as errors so the missing include cannot regress silently. The flag is supplied through the CFLAGS environment variable, preserving the normal makefile flags.

## Validation

- Confirmed unpatched master fails a standalone syntax check with -Werror=implicit-function-declaration at the memset call.
- Confirmed the patched GPU source compiles with that flag active.
- All 68 GPU-indirect core tests passed on DGX Spark (GB10, CUDA 13.0), including spectral cones, using OpenBLAS 0.3.34 and no kernel override.

Independent of the separate CUDA compiler-default fix; either PR can merge first.