### PR TITLE
docs: fix broken CLAUDE.md reference, document spectral-test skip

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,6 +21,17 @@ make DLONG=1 USE_LAPACK=1
 make purge
 ```
 
+> **The spectral-cone tests are skipped by default.** `USE_SPECTRAL_CONES`
+> defaults to `0` (see `scs.mk`), so a default `make test` reports eight tests
+> as `skipped` and exercises none of `src/spectral_cones/` — while still
+> printing `ALL TESTS PASSED`. If you touch the log-determinant, nuclear-norm,
+> sum-of-largest or ell1 cone code, build and test with the flag enabled:
+>
+> ```bash
+> make test USE_SPECTRAL_CONES=1
+> ./out/run_tests_direct
+> ```
+
 ## Development Workflow
 
 1. Fork the repo and create a feature branch from `master`
@@ -45,5 +56,12 @@ make purge
 | `test/` | Test suite (minunit framework) |
 | `docs/src/` | Sphinx documentation source |
 
-See `CLAUDE.md` for architecture details and guides on adding new solver
-backends or cone types.
+## Where to Read Next
+
+| Topic | Reference |
+|-------|-----------|
+| Algorithm, termination criteria, scaling | [`docs/src/algorithm/`](docs/src/algorithm/) ([online](https://www.cvxgrp.org/scs/algorithm/)) |
+| Linear solver backends and the KKT system | [`docs/src/linear_solver/`](docs/src/linear_solver/) ([online](https://www.cvxgrp.org/scs/linear_solver/)) |
+| **Adding a new linear solver backend** | [Implementing a new linear solver](https://www.cvxgrp.org/scs/linear_solver/#implementing-a-new-linear-solver) — implement `ScsLinSysWork` and the functions in `include/linsys.h`; see `linsys/` for seven worked examples |
+| Supported cones and their data layout | [`docs/src/api/cones.rst`](docs/src/api/cones.rst) ([online](https://www.cvxgrp.org/scs/api/cones.html)) |
+| Compile-time flags | [`docs/src/api/compile_flags.rst`](docs/src/api/compile_flags.rst) ([online](https://www.cvxgrp.org/scs/api/compile_flags.html)) |

--- a/README.md
+++ b/README.md
@@ -52,6 +52,10 @@ make test               # Build test binaries
 ./out/run_tests_indirect
 ```
 
+Note that the spectral-cone tests are skipped unless SCS is built with
+`USE_SPECTRAL_CONES=1` (see the flag table below); a default `make test` run
+reports them as `skipped`.
+
 ### CMake
 
 ```bash


### PR DESCRIPTION
Two documentation fixes, both found by an audit of this repo. Docs only — no code, no build files touched.

## Fixes #439 — `CONTRIBUTING.md` pointed at an untracked file

`CONTRIBUTING.md:48` sent contributors to `CLAUDE.md` for architecture details and for guides on adding solver backends or cone types. That file is gitignored (`.gitignore:57`) and untracked, so a fresh clone never had it — it stopped being tracked in bb79dd56. The pointer was load-bearing: it was the only place the file offered for the two things a new contributor is most likely to want.

Replaced with a table of the tracked docs that actually cover this ground. Worth noting what the audit turned up while checking each target:

- **The backend guide is real** — "Implementing a new linear solver" (`docs/src/linear_solver/index.rst:180`), with the `ScsLinSysWork` contract, `include/linsys.h`, and seven worked examples under `linsys/`.
- **A cone-extension guide was never written.** `docs/src/api/cones.rst` documents which cones exist and their data layout, but not how to add one. So the cone entry is listed as reference material rather than as a how-to — repointing at a second document that doesn't exist would only relocate the bug.

Every path and anchor in the new table was verified to resolve. `git grep CLAUDE.md` now hits only `.gitignore`.

## Fixes #440 — spectral-cone tests skip silently

`scs.mk:210` defaults `USE_SPECTRAL_CONES = 0`, so the default build omits the spectral objects and `test/run_tests.c` substitutes `_SKIP(...)` stubs for the eight spectral tests:

```
Running test: exp_design
skipped
... (robust_pca, graph_partitioning, several_sum_largest, several_nuc_cone,
     several_logdet_cones, test_ell1_cone, test_ell1_and_nuc)
ALL TESTS PASSED
Tests run: 60
```

`ALL TESTS PASSED` is accurate and the `_SKIP` macro correctly decrements `tests_run`, so the count stays honest — but neither `README.md` nor `CONTRIBUTING.md` said that a default `make test` exercises none of `src/spectral_cones/`. Someone changing the log-determinant, nuclear-norm, sum-of-largest or ell1 cone code could run the suite, see it green, and have tested nothing they touched.

CI already covers the path (`build_spectral.yml` matrixes `spectral: [0, 1]`), so the gap was local-only — which is where it was most likely to mislead. Documented in the `CONTRIBUTING.md` quick start and the README build block, the latter cross-referencing the flag table that was already there.

## Verification

The command added to the docs was run, not just written:

```
$ make test USE_SPECTRAL_CONES=1     # clean build, spectral objects linked
$ ./out/run_tests_direct
ALL TESTS PASSED
Tests run: 68                        # was 60; none of the eight skipped
```

Also confirmed: all four default backends still pass 60/60 (`direct`, `indirect`, `dense`, `accelerate`), the edited README's fences still parse, and the build is warning-free under `-Wall -Wwrite-strings -pedantic -Wstrict-prototypes`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
