### PR TITLE
Invalidate spectral warm starts on metric change; size syev workspace from its own query

### DIFF
--- a/include/cones.h
+++ b/include/cones.h
@@ -98,6 +98,7 @@ void SCS(set_r_y)(const ScsConeWork *c, scs_float scale, scs_float *r_y);
 void SCS(enforce_cone_boundaries)(const ScsConeWork *c, scs_float *vec,
                                   scs_float (*f)(const scs_float *, scs_int),
                                   scs_int psd_rank1);
+void SCS(reset_cone_cache)(ScsConeWork *c);
 
 #ifdef __cplusplus
 }

--- a/src/cones.c
+++ b/src/cones.c
@@ -76,16 +76,16 @@ void BLASC(heevr)(const char *jobz, const char *range, const char *uplo,
                   scs_float *rwork, blas_int *lrwork, blas_int *iwork,
                   blas_int *liwork, blas_int *info);
 
-blas_int BLAS(syrk)(const char *uplo, const char *trans, const blas_int *n,
-                    const blas_int *k, const scs_float *alpha,
-                    const scs_float *a, const blas_int *lda,
-                    const scs_float *beta, scs_float *c, const blas_int *ldc);
+void BLAS(syrk)(const char *uplo, const char *trans, const blas_int *n,
+                const blas_int *k, const scs_float *alpha, const scs_float *a,
+                const blas_int *lda, const scs_float *beta, scs_float *c,
+                const blas_int *ldc);
 
-blas_int BLASC(herk)(const char *uplo, const char *trans, const blas_int *n,
-                     const blas_int *k, const scs_float *alpha,
-                     const SCS_BLAS_COMPLEX_TYPE *a, const blas_int *lda,
-                     const scs_float *beta, SCS_BLAS_COMPLEX_TYPE *c,
-                     const blas_int *ldc);
+void BLASC(herk)(const char *uplo, const char *trans, const blas_int *n,
+                 const blas_int *k, const scs_float *alpha,
+                 const SCS_BLAS_COMPLEX_TYPE *a, const blas_int *lda,
+                 const scs_float *beta, SCS_BLAS_COMPLEX_TYPE *c,
+                 const blas_int *ldc);
 
 void BLAS(scal)(const blas_int *n, const scs_float *sa, scs_float *sx,
                 const blas_int *incx);
@@ -93,6 +93,10 @@ void BLASC(scal)(const blas_int *n, const SCS_BLAS_COMPLEX_TYPE *sa,
                  SCS_BLAS_COMPLEX_TYPE *sx, const blas_int *incx);
 
 #ifdef USE_SPECTRAL_CONES
+void BLAS(syev)(const char *jobz, const char *uplo, blas_int *n, scs_float *a,
+                blas_int *lda, scs_float *w, scs_float *work, blas_int *lwork,
+                blas_int *info);
+
 void BLAS(gesvd)(const char *jobu, const char *jobvt, const blas_int *m,
                  const blas_int *n, scs_float *a, const blas_int *lda,
                  scs_float *s, scs_float *u, const blas_int *ldu, scs_float *vt,
@@ -964,6 +968,35 @@ static scs_int set_up_cone_work_spaces(ScsConeWork *c, const ScsCone *k) {
     liwork_max = MAX(liwork_max, iwkopt);
   }
 
+#ifdef USE_SPECTRAL_CONES
+  /* 1b. Spectral Workspace Query (syev)
+   *
+   * The logdet and sum-of-largest projections eigendecompose with syev, not
+   * syevr, but share the consolidated 'work' array sized above. Sizing that
+   * array from the syevr query alone shortchanges syev: both LAPACKs we
+   * measured (Apple Accelerate and netlib) report an optimum of 34n for
+   * syev against 33n for syevr, so every spectral syev call was running
+   * below its optimum. That stays above syev's *minimum* of 3n-1, so it
+   * costs block size rather than correctness, but a vendor whose optimum
+   * and minimum are closer together would push it under the minimum and
+   * syev would start failing with info = -8 deep inside a projection.
+   * Query syev too and keep whichever workspace is larger.
+   */
+  if (k->dsize > 0 || k->sl_size > 0) {
+    blas_int n_max_spectral = MAX(n_max_logdet, n_max_sl);
+
+    BLAS(syev)("V", "L", &n_max_spectral, c->Xs, &n_max_spectral, c->e, &wkopt,
+               &neg_one, &info);
+
+    if (info != 0) {
+      scs_printf("FATAL: syev workspace query failure, info = %li\n",
+                 (long)info);
+      return -1;
+    }
+    lwork_max = MAX(lwork_max, (blas_int)(wkopt + 1));
+  }
+#endif
+
   /* 2. Complex PSD Workspace Query (heevr) */
   if (k->cssize > 0) {
     c->cXs = (scs_complex_float *)scs_calloc(n_max_csd * n_max_csd,
@@ -1677,6 +1710,36 @@ ScsConeWork *SCS(init_cone)(ScsCone *k, scs_int m) {
 #endif
 
   return c;
+}
+
+/* Discard inner-solver state that was cached under a previous metric.
+ *
+ * The standard cones project in closed form, so their projections are a
+ * function of the point and the current metric alone. The spectral cones
+ * are not: proj_logdet_cone runs a Newton/IPM inner solve and warm-starts
+ * Newton from the projection it produced on the previous outer iteration.
+ * That saved iterate belongs to the metric that produced it -- once diag_r
+ * changes, the point being projected jumps, and the stale iterate is no
+ * longer a good (nor necessarily a domain-interior) starting point. So
+ * callers must invalidate it whenever the metric changes, and whenever a
+ * new solve begins.
+ *
+ * Clearing the flags is a complete invalidation: saved_log_projs is read
+ * only where the matching flag is set, log_cone_Newton writes every
+ * component of its output on the cold path, and the IPM fallback always
+ * starts from the all-ones point, so it carries nothing across iterations.
+ *
+ * Dropping a warm start only costs inner iterations, never correctness,
+ * which is why this is safe to call unconditionally.
+ */
+void SCS(reset_cone_cache)(ScsConeWork *c) {
+#ifdef USE_SPECTRAL_CONES
+  if (c && c->k && c->log_cone_warmstarts && c->k->dsize > 0) {
+    memset(c->log_cone_warmstarts, 0, c->k->dsize * sizeof(bool));
+  }
+#else
+  (void)c;
+#endif
 }
 
 /* Outward facing cone projection routine, performs projection in-place.

--- a/src/scs.c
+++ b/src/scs.c
@@ -1114,17 +1114,6 @@ static ScsWork *init_work(const ScsData *d, const ScsCone *k,
   w->r_orig = init_residuals(w->d);
   w->b_orig = (scs_float *)scs_calloc(w->d->m, sizeof(scs_float));
   w->c_orig = (scs_float *)scs_calloc(w->d->n, sizeof(scs_float));
-#ifdef USE_SPECTRAL_CONES
-  if (w->stgs->adaptive_diag_scale &&
-      (w->k->dsize || w->k->nucsize || w->k->ell1_size || w->k->sl_size)) {
-    /* The spectral-cone projections are iterative inner solvers with
-     * warm-start state that does not currently tolerate mid-solve metric
-     * changes (observed as dual iterates leaving the cone). Disable
-     * dynamic diagonal rescaling on such problems until the inner
-     * solvers are made metric-change aware. */
-    w->stgs->adaptive_diag_scale = 0;
-  }
-#endif
   if (w->stgs->adaptive_diag_scale) {
     if (!w->stgs->adaptive_scale) {
       /* silently disable: diag scaling rides the adaptive-scale update
@@ -1259,6 +1248,10 @@ static scs_int update_work(ScsWork *w, ScsSolution *sol) {
   } else {
     cold_start_vars(w);
   }
+
+  /* the cached spectral warm starts describe the iterates of the previous
+   * solve, which the (re)start above has just discarded */
+  SCS(reset_cone_cache)(w->cone_work);
 
   update_work_cache(w);
   return 0;
@@ -1410,6 +1403,11 @@ static scs_int update_scale(ScsWork *w, const ScsCone *k, scs_int iter) {
     if (w->accel) {
       aa_reset(w->accel);
     }
+    /* Same reasoning for the cone projections: the spectral cones' inner
+     * solvers warm-start from state computed under the metric we just
+     * replaced, so drop it rather than let it seed the next iteration's
+     * projection (see SCS(reset_cone_cache)). */
+    SCS(reset_cone_cache)(w->cone_work);
     /* update v, using fact that rsk, u, u_t vectors should be the same */
     /* solve: R^+ (v^+ + u - 2u_t) = rsk = R(v + u - 2u_t)
      *  => v^+ = R+^-1 rsk + 2u_t - u

--- a/src/spectral_cones/logdeterminant/logdet_cone.c
+++ b/src/spectral_cones/logdeterminant/logdet_cone.c
@@ -27,10 +27,10 @@ extern "C" {
 void BLAS(syev)(const char *jobz, const char *uplo, blas_int *n, scs_float *a,
                 blas_int *lda, scs_float *w, scs_float *work, blas_int *lwork,
                 blas_int *info);
-blas_int BLAS(syrk)(const char *uplo, const char *trans, const blas_int *n,
-                    const blas_int *k, const scs_float *alpha,
-                    const scs_float *a, const blas_int *lda,
-                    const scs_float *beta, scs_float *c, const blas_int *ldc);
+void BLAS(syrk)(const char *uplo, const char *trans, const blas_int *n,
+                const blas_int *k, const scs_float *alpha, const scs_float *a,
+                const blas_int *lda, const scs_float *beta, scs_float *c,
+                const blas_int *ldc);
 void BLAS(scal)(const blas_int *n, const scs_float *sa, scs_float *sx,
                 const blas_int *incx);
 
@@ -96,12 +96,13 @@ scs_int SCS(proj_logdet_cone)(scs_float *tvX, scs_int n, ScsConeWork *c,
      * order (smallest eigenvalue first)
      */
     BLAS(syev)("Vectors", "Lower", &nb, Xs, &nb, e, work, &lwork, &info);
+    /* info < 0: bad argument. info > 0: no convergence, so 'e' and 'Xs' hold
+     * partial results. Either way the eigendecomposition below it is built on
+     * is meaningless, so fail rather than return a bogus projection. */
     if (info != 0) {
-      scs_printf("WARN: LAPACK syev error, info = %i\n", (int)info);
-      if (info < 0) {
-        scs_printf("entering LAPACK stuff!\n");
-        return info;
-      }
+      scs_printf("FATAL: LAPACK syev error in logdet cone, info = %li\n",
+                 (long)info);
+      return -1;
     }
 
     /*

--- a/src/spectral_cones/sum-largest/sum_largest_eval_cone.c
+++ b/src/spectral_cones/sum-largest/sum_largest_eval_cone.c
@@ -96,11 +96,13 @@ scs_int SCS(proj_sum_largest_evals)(scs_float *tX, scs_int n, scs_int k,
    * order (smallest eigenvalue first)
    */
   BLAS(syev)("Vectors", "Lower", &nb, Xs, &nb, e, work, &lwork, &info);
+  /* info < 0: bad argument. info > 0: no convergence, so 'e' and 'Xs' hold
+   * partial results. Either way the eigendecomposition below it is built on
+   * is meaningless, so fail rather than return a bogus projection. */
   if (info != 0) {
-    scs_printf("WARN: LAPACK syev error, info = %i\n", (int)info);
-    if (info < 0) {
-      return info;
-    }
+    scs_printf("FATAL: LAPACK syev error in sum-of-largest cone, info = %li\n",
+               (long)info);
+    return -1;
   }
 
   /*

--- a/test/run_tests.c
+++ b/test/run_tests.c
@@ -80,6 +80,7 @@ _SKIP(rob_gauss_cov_est)
 #include "spectral_cones_problems/several_sum_largest.h"
 #include "spectral_cones_problems/test_ell1_cone.h"
 #include "spectral_cones_problems/test_ell1_and_nuc.h"
+#include "spectral_cones_problems/test_spectral_metric_updates.h"
 #else
 _SKIP(exp_design)
 _SKIP(robust_pca)
@@ -89,6 +90,7 @@ _SKIP(several_nuc_cone)
 _SKIP(several_logdet_cones)
 _SKIP(test_ell1_cone)
 _SKIP(test_ell1_and_nuc)
+_SKIP(test_spectral_metric_updates)
 #endif
 
 /* solves problems from data files */
@@ -173,6 +175,7 @@ static void all_tests(void) {
   mu_run_test(several_logdet_cones);
   mu_run_test(test_ell1_cone);
   mu_run_test(test_ell1_and_nuc);
+  mu_run_test(test_spectral_metric_updates);
 }
 int main(void) {
   int i;

--- a/test/spectral_cones_problems/test_spectral_metric_updates.h
+++ b/test/spectral_cones_problems/test_spectral_metric_updates.h
@@ -1,0 +1,161 @@
+#include "glbopts.h"
+#include "linalg.h"
+#include "minunit.h"
+#include "problem_utils.h"
+#include "scs.h"
+#include "scs_matrix.h"
+#include "util.h"
+
+/*
+ * Spectral cones under mid-solve metric changes.
+ *
+ * Unlike the closed-form projections of the standard cones, the spectral-cone
+ * projections are iterative inner solvers that carry warm-start state across
+ * outer iterations (log_cone_warmstarts, saved_log_projs). Both the scalar
+ * adaptive_scale and the dynamic diagonal rescaling change the diag_r metric
+ * mid-solve, and that state belongs to the metric that produced it, so
+ * update_scale drops it via SCS(reset_cone_cache). This test covers the
+ * interaction that hook exists for.
+ *
+ * A regression here is silent: the projections are the only writers of the
+ * dual iterate and the SCS residuals never test cone membership, so a bad
+ * projection terminates 'solved' with a correct objective and a y far outside
+ * the dual cone. The objective checks below would not catch it; the cone
+ * distance checks are the point of this test.
+ *
+ * The problem is the exp_design D-optimal design instance (one logdet cone,
+ * the projection with the Newton/IPM inner solver and warm-start cache). We
+ * solve it repeatedly from initial scales spanning eight orders of magnitude,
+ * which forces many metric updates rather than the handful a well-scaled
+ * start produces, and assert that every solve lands on the cone.
+ */
+static const char *test_spectral_metric_updates(void) {
+  /* initial scales far from the value the heuristic settles on, so that
+   * adaptive_scale and the diagonal rescaling both fire repeatedly.
+   * The range stops at 1e-3: this instance's logdet projection diverges
+   * from a 1e-4 start (on master too, at iteration 0 before any metric
+   * update), which is a separate robustness limit and not what this test
+   * is about. */
+  static const scs_float scales[] = {1e-3, 1e-2, 1e-1, 1e0,
+                                     1e1,  1e2,  1e3,  1e4};
+  const scs_int n_scales = (scs_int)(sizeof(scales) / sizeof(scales[0]));
+  scs_int total_scale_updates = 0;
+  scs_int trial;
+
+  /* exp_design data: m = 15, n = 8, one logdet cone of dimension 3 */
+  scs_float Ax[] = {
+      -1.,         1.,          -1.,         3.24,        0.16,
+      1.,          4.84,        3.61,        1.,          -1.,
+      2.54558441,  -0.11313708, -0.14142136, 1.24450793,  0.26870058,
+      -2.12132034, -1.,         2.03646753,  0.05656854,  0.56568542,
+      0.93338095,  4.03050865,  0.28284271,  -1.,         1.,
+      0.04,        0.01,        0.16,        0.01,        2.25,
+      -1.,         1.13137085,  -0.02828427, -0.05656854, 0.16970563,
+      0.21213203,  -0.42426407, -1.,         0.64,        0.01,
+      0.16,        0.09,        2.25,        0.04,        -1.};
+  scs_int Ai[] = {7,  0,  8, 1, 2, 3, 4, 5,  6,  9, 1, 2, 3, 4, 5,
+                  6,  10, 1, 2, 3, 4, 5, 6,  11, 1, 2, 3, 4, 5, 6,
+                  12, 1,  2, 3, 4, 5, 6, 13, 1,  2, 3, 4, 5, 6, 14};
+  scs_int Ap[] = {0, 1, 3, 10, 17, 24, 31, 38, 45};
+
+  scs_float b[] = {1., 1., 1., 1., 1., 1., 1., 0., 0., 0., 0., 0., 0., 0., 0.};
+  scs_float c[] = {1., 0., 0., 0., 0., 0., 0., 0.};
+
+  scs_int m = 15;
+  scs_int n = 8;
+  scs_int d_array[] = {3};
+
+  /* computed using mosek (Ax above is truncated, mosek solved the problem
+   * with the non-truncated data) */
+  scs_float opt = 3.0333290743428574;
+
+  for (trial = 0; trial < n_scales; ++trial) {
+    ScsCone *k = (ScsCone *)scs_calloc(1, sizeof(ScsCone));
+    ScsData *d = (ScsData *)scs_calloc(1, sizeof(ScsData));
+    ScsSettings *stgs = (ScsSettings *)scs_calloc(1, sizeof(ScsSettings));
+    ScsSolution *sol = (ScsSolution *)scs_calloc(1, sizeof(ScsSolution));
+    ScsConeWork *cone_work;
+    ScsInfo info = {0};
+    scs_int exitflag;
+    scs_float perr, derr, ydist, sdist;
+
+    d->m = m;
+    d->n = n;
+    d->b = b;
+    d->c = c;
+
+    d->A = (ScsMatrix *)scs_calloc(1, sizeof(ScsMatrix));
+    d->A->m = m;
+    d->A->n = n;
+    d->A->x = Ax;
+    d->A->i = Ai;
+    d->A->p = Ap;
+
+    k->z = 1;
+    k->l = 6;
+    k->d = d_array;
+    k->dsize = 1;
+
+    scs_set_default_settings(stgs);
+    stgs->eps_abs = 1e-7;
+    stgs->eps_rel = 1e-7;
+    stgs->eps_infeas = 1e-9;
+    stgs->scale = scales[trial];
+    /* both metric-update mechanisms on: the scalar heuristic and the
+     * dynamic diagonal rescaling that updates far more often */
+    stgs->adaptive_scale = 1;
+    stgs->adaptive_diag_scale = 1;
+
+    exitflag = scs(d, k, stgs, sol, &info);
+
+    perr = SCS(dot)(d->c, sol->x, d->n) - opt;
+    derr = -SCS(dot)(d->b, sol->y, d->m) - opt;
+
+    scs_printf("scale %.0e: %li scale updates, primal err %.4e, dual err "
+               "%.4e\n",
+               stgs->scale, (long)info.scale_updates, perr, derr);
+
+    mu_assert("test_spectral_metric_updates: SCS failed to produce "
+              "outputflag SCS_SOLVED",
+              exitflag == SCS_SOLVED);
+    mu_assert_less("test_spectral_metric_updates: primal obj ERROR", ABS(perr),
+                   1e-4);
+    mu_assert_less("test_spectral_metric_updates: dual obj ERROR", ABS(derr),
+                   1e-4);
+
+    /* the actual regression check: a projection that mishandled the metric
+     * change leaves y outside the dual cone (and s outside the cone) while
+     * the objective above still looks right */
+    cone_work = SCS(init_cone)(k, m);
+    mu_assert("test_spectral_metric_updates: failed to init cone work",
+              cone_work != SCS_NULL);
+    ydist = get_dual_cone_dist(sol->y, cone_work, m);
+    sdist = get_pri_cone_dist(sol->s, cone_work, m);
+    SCS(finish_cone)(cone_work);
+
+    scs_printf("scale %.0e: y cone dist %.4e, s cone dist %.4e\n",
+               stgs->scale, ydist, sdist);
+
+    mu_assert_less("test_spectral_metric_updates: y cone dist ERROR",
+                   ABS(ydist), 1e-5);
+    mu_assert_less("test_spectral_metric_updates: s cone dist ERROR",
+                   ABS(sdist), 1e-5);
+
+    total_scale_updates += info.scale_updates;
+
+    scs_free(d->A);
+    scs_free(k);
+    scs_free(stgs);
+    scs_free(d);
+    SCS(free_sol)(sol);
+  }
+
+  /* Guard the guard: if the metric never changed mid-solve, the checks above
+   * are vacuous and this test has silently stopped covering the interaction.
+   */
+  mu_assert("test_spectral_metric_updates: no metric updates were triggered, "
+            "so the test no longer exercises mid-solve metric changes",
+            total_scale_updates > 0);
+
+  return 0;
+}


### PR DESCRIPTION
Closes #405. Addresses the latent `syev` defects behind #404, but **not** the crash #404 reports — see the last section.

## #405: spectral warm starts survived metric changes

The spectral-cone projections are iterative inner solvers, unlike the closed-form projections of the standard cones. `proj_logdet_cone` warm-starts Newton from the projection it produced on the previous outer iteration (`log_cone_Newton.c:143`), and **nothing ever invalidated that state** — `log_cone_warmstarts` was allocated in `init_cone` and never cleared anywhere. So the cache survived every mid-solve change to the `diag_r` metric.

That saved iterate belongs to the metric that produced it: once `diag_r` changes, the point being projected jumps, and the stale start is no longer a good — nor necessarily a domain-interior — initializer.

Fix: add `SCS(reset_cone_cache)` and call it where the metric or the iterates get replaced:

- alongside `aa_reset` in `update_scale`, which is where the issue points;
- in `update_work`, so one solve's cache cannot seed the next.

Clearing the flags is a *complete* invalidation, which I checked rather than assumed:

- `saved_log_projs` is read only where the matching flag is set;
- `log_cone_Newton` writes every component of its output on the cold path (`*t` on all four exit paths);
- the IPM fallback always cold-starts from the all-ones point (`log_cone_IPM.c:116`), so it carries nothing across iterations.

Dropping a warm start costs inner iterations, never correctness, so the reset is safe to call unconditionally. With the hazard closed, the `init_work` carve-out that disabled dynamic diagonal rescaling on spectral problems is removed, as #405 asks.

I checked the box cone for the same family of bug: it needs nothing. `r_box_inv` is recomputed inside `proj_box_cone` from the current `r_box`, and `box_t_warm_start` only seeds a monotone 1-D Newton.

## #404: `syev` workspace and ignored `info`

The spectral projections call `syev`, but the shared `c->work` array was sized from the `syevr` query alone. Measured, rather than read off the LAPACK contract:

```
n=   3 syevr lwork=99    | syev lwork=102
n= 100 syevr lwork=3300  | syev lwork=3400
n= 200 syevr lwork=6600  | syev lwork=6800
```

`syev`'s optimum (34n) is the **larger** of the two, at every `n` tested, on both Apple Accelerate and netlib — the opposite of what one might assume from the documented minima (26n vs 3n-1), so the inherited comment on this point is rewritten around the measured numbers. It stays above `syev`'s *minimum* of 3n-1, so today it costs block size rather than correctness (confirmed: no ASan report), but a vendor whose optimum and minimum sit closer together would push it under the minimum and `syev` would fail with `info = -8` inside a projection. Now queried and maxed.

Second, a silent-corruption bug: both `syev` call sites printed `WARN` on `info > 0` and then **used the partial eigendecomposition anyway**, returning the positive `info` as a status that callers read as success. They now fail with `-1`, which propagates to a clean `SCS_FAILED`.

Also declares `syrk`/`herk` as returning `void` rather than `blas_int`.

## Test

Adds a spectral test that forces metric updates mid-solve: the `exp_design` logdet instance solved from initial scales spanning eight orders of magnitude, with both `adaptive_scale` and `adaptive_diag_scale` on, asserting **cone membership of the returned iterates** rather than only the objective — a mishandled metric change is silent in the objective, which is what made #405 hard to see. It also guards itself by asserting that metric updates actually fired.

To be clear about what it is: this is the CI guard #405 asks for (fix direction 3), **not a failing reproducer**. It passes without the invalidation hook too.

## What did not reproduce

**#404's segfault did not reproduce here** at `2c2cd1a9`: clean, and under `-fsanitize=address -fsanitize=undefined -fno-sanitize-recover=all` with `DLONG=1`, across the `direct`, `indirect`, `dense` and `accelerate` backends, against both `-llapack -lblas` and `-framework Accelerate`. All green. This PR fixes the mechanism #404 hypothesises, but it cannot claim the crash is fixed, so **#404 should stay open pending a re-test on the reporting machine**.

Likewise, #405's originally reported symptom (`y cone dist ERROR: 1.349e-01`) no longer reproduces at current master even with the carve-out removed and no invalidation — the row-profile floor from `bbbf766b` seems to have made the diagonal rescaling milder. The hazard in the code was real and unfixed regardless, which is what this PR closes.

## Verification

- 69/69 on `direct`, `indirect`, `dense`, `accelerate`
- 69/69 sanitized (ASan + UBSan, `-fno-sanitize-recover=all`) with `DLONG=1`
- 60/60 with `USE_SPECTRAL_CONES=0`, exercising the non-spectral `reset_cone_cache` path

`cmake` is not installed on this machine, so the CMake build paths are unverified locally and ride on CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
