### PR TITLE
Correct factual errors in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,9 +26,9 @@ subject to  Ax + s = b, s in K
 where `K` is a product of convex cones. It uses an operator-splitting method
 (ADMM) with Anderson acceleration to achieve fast convergence.
 
-**Supported cones:** linear (LP), second-order (SOCP), semidefinite (SDP),
-exponential, power, complex semidefinite, and spectral cones (log-determinant,
-nuclear norm, sum-of-largest eigenvalues).
+**Supported cones:** zero/linear (LP), box, second-order (SOCP), semidefinite
+(SDP), complex semidefinite, exponential, power, and spectral cones
+(log-determinant, nuclear norm, ell1-norm, sum-of-largest eigenvalues).
 
 ## Features
 
@@ -36,6 +36,8 @@ nuclear norm, sum-of-largest eigenvalues).
   iterative (CG), Intel MKL Pardiso, Apple Accelerate (macOS), NVIDIA cuDSS, GPU
 - Anderson acceleration for faster convergence, including solve diagnostics
 - Problem data normalization/equilibration for numerical stability
+- Adaptive dual scaling, with per-row diagonal rescaling driven by residual
+  profiles (`adaptive_diag_scale`, on by default)
 - Warm-starting and incremental `b`/`c` updates via `scs_update`
 - Ctrl-C signal handling for graceful interruption
 - Configurable precision (`float`/`double`) and index type (`int`/`long long`)
@@ -87,7 +89,9 @@ SCS has interfaces for several languages:
 - **MATLAB:** See the [documentation](https://www.cvxgrp.org/scs/install/matlab.html)
 - **Ruby:** [scs-ruby](https://github.com/ankane/scs-ruby)
 
-SCS is the default solver in [CVXPY](https://www.cvxpy.org/).
+In [CVXPY](https://www.cvxpy.org/), SCS is the default solver for semidefinite,
+exponential-cone and power-cone problems (Clarabel handles LPs and SOCPs, OSQP
+handles QPs).
 
 ## Project Structure
 
@@ -95,9 +99,9 @@ SCS is the default solver in [CVXPY](https://www.cvxpy.org/).
 include/        Public API and internal headers
 src/            Core solver implementation
 linsys/         Linear solver backends (pluggable architecture)
-  cpu/direct/     Sparse Cholesky (QDLDL, default)
+  cpu/direct/     Sparse LDLt (AMD ordering + QDLDL, default)
   cpu/indirect/   Conjugate gradient
-  cpu/dense/      Dense LU (LAPACK dgetrf, for small problems)
+  cpu/dense/      Dense Cholesky on the Gram reduction (LAPACK dpotrf)
   mkl/direct/     Intel MKL Pardiso
   accelerate/direct/  Apple Accelerate sparse LDLt (macOS)
   cudss/direct/   NVIDIA cuDSS

--- a/README.md
+++ b/README.md
@@ -83,10 +83,10 @@ Example: `make DLONG=1 USE_LAPACK=1`
 
 SCS has interfaces for several languages:
 
-- **Python:** `pip install scs` ([PyPI](https://pypi.org/project/scs/))
+- **Python:** [scs-python](https://github.com/bodono/scs-python) (`pip install scs`, [PyPI](https://pypi.org/project/scs/))
 - **Julia:** [SCS.jl](https://github.com/jump-dev/SCS.jl)
 - **R:** [scs](https://cran.r-project.org/package=scs)
-- **MATLAB:** See the [documentation](https://www.cvxgrp.org/scs/install/matlab.html)
+- **MATLAB:** [scs-matlab](https://github.com/bodono/scs-matlab) ([install guide](https://www.cvxgrp.org/scs/install/matlab.html))
 - **Ruby:** [scs-ruby](https://github.com/ankane/scs-ruby)
 
 In [CVXPY](https://www.cvxpy.org/), SCS is the default solver for semidefinite,


### PR DESCRIPTION
## Summary

An accuracy audit of `README.md` against the 3.3.1 source. Most of it checks out — version strings, build-flag defaults, the make/cmake flows, the project tree, badge URLs — but six claims needed correcting. Documentation only; no source changes.

| Claim | Corrected to | Source of truth |
|---|---|---|
| `cpu/dense/` is "Dense LU (LAPACK dgetrf)" | Dense Cholesky on the Gram reduction (`dpotrf`) | `linsys/cpu/dense/private.c:46` reports `"dense-direct-cholesky"`; `dgetrf` appears nowhere in the repo |
| Box cone missing from supported cones | added | `include/scs.h:132-138` (`bu`/`bl`/`bsize`, compiled unconditionally) |
| ell1-norm cone missing from spectral cones | added | `include/scs.h:171-172`; also exercised by `test_ell1_cone` |
| `cpu/direct/` is "Sparse Cholesky (QDLDL)" | Sparse LDLt (AMD ordering + QDLDL) | `linsys/cpu/direct/private.c:213` reports `"sparse-direct-amd-qdldl"`; the KKT matrix is indefinite |
| "SCS is the default solver in CVXPY" | default for SDP / exponential-cone / power-cone problems | Clarabel became the default for LPs and SOCPs in CVXPY 1.5; OSQP handles QPs ([docs](https://www.cvxpy.org/tutorial/solvers/index.html)) |
| `adaptive_diag_scale` undocumented | added a Features bullet | `include/glbopts.h:48` `ADAPTIVE_DIAG_SCALE (1)`, applied at `src/util.c:176` |

The cone list is also reordered to match `ScsCone`, which is the order rows of `A` must be supplied in, and "linear" is now "zero/linear" so it covers the `z` field.

## Second commit: interface repo links

The Language Interfaces list named source repositories for Julia and Ruby but not for Python or MATLAB — Python linked only PyPI, MATLAB only the install guide — even though `docs/src/install/python.rst:24` and `docs/src/install/matlab.rst:13` already point at `bodono/scs-python` and `bodono/scs-matlab`. Both entries now name the upstream repository alongside the existing links, so every language in the list is consistent. All seven URLs in the section verified to return 200.

## Testing

Confirmed the documented build flow still holds end to end:

```
make && make test
./out/run_tests_direct     # ALL TESTS PASSED — Tests run: 62
./out/run_tests_indirect   # ALL TESTS PASSED — Tests run: 62
```

Spectral-cone tests report `skipped` on a default build, which is what the README already documents.

Cross-checked that `3.3.1` remains consistent across `README.md`, `include/glbopts.h:26`, `CITATION.cff` and `docs/src/conf.py:27`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)