### PR TITLE
Build the docs on pull requests, and deploy only from the canonical repo

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -4,6 +4,10 @@ on:
   push:
     branches:
       - master
+  # Build (but do not deploy) on pull requests, so that changes to the docs or
+  # to the docs build are validated before they reach master and the published
+  # site. Every other workflow in this directory already runs on pull_request.
+  pull_request:
 
 jobs:
   build-and-deploy:
@@ -24,7 +28,12 @@ jobs:
       - name: Build docs
         run: |
           cd docs/src && make docs && touch ../.nojekyll
+      # Deploying needs a writable GITHUB_TOKEN, which forks do not get by
+      # default, and a fork publishing its own copy of the docs is not wanted
+      # anyway -- so restrict the deploy to a push on the canonical repo. On
+      # pull requests and on forks the job stops after the build above.
       - name: Deploy
+        if: github.event_name == 'push' && !github.event.repository.fork
         uses: JamesIves/github-pages-deploy-action@v4.8.0
         with:
           branch: gh-pages # The branch the action should deploy to.


### PR DESCRIPTION
## Two problems

**1. Docs changes are never validated before merge.** `docs.yml` is the only one of the fourteen workflows in `.github/workflows/` without a `pull_request` trigger:

```
$ for f in .github/workflows/*.yml; do grep -q pull_request $f && echo "$(basename $f)"; done
build.yml  build_mkl.yml  build_openmp.yml  build_spectral.yml  buildpp.yml
cmake.yml  cmake_consume.yml  cmake_cudss.yml  cmake_mkl.yml  cmake_openmp.yml
gpu.yml  mkl_interface_mismatch.yml  valgrind.yml          # docs.yml absent
```

So a change to the documentation, to `docs/src/Makefile`, or to the docs build reaches `master` unexercised, and a mistake surfaces only once it has broken the published site.

**2. The deploy step fails on every fork.** Deploying force-pushes to `gh-pages`, which needs a writable `GITHUB_TOKEN`. Forks default to read-only, so after an otherwise successful build the job dies with:

```
remote: Permission to tschm/scs.git denied to github-actions[bot].
fatal: unable to access 'https://github.com/tschm/scs.git/': The requested URL returned error: 403
##[error]The deploy step encountered an error
```

Any fork that pushes to its `master` hits this. And even with write access, a fork publishing a rival copy of the docs is not wanted.

## Change

- Add a `pull_request` trigger. The `push` trigger stays restricted to `master`, so a branch push does not also fire the workflow — pull requests build exactly once.
- Gate `Deploy` on `github.event_name == 'push' && !github.event.repository.fork`. On pull requests and on forks the job now stops after the build, which is the part worth running there.

Using `!github.event.repository.fork` rather than a hardcoded repository name means forks work without their owners having to change Actions permission settings.

## Verification

- Workflow YAML parses; triggers resolve to `{"push": {"branches": ["master"]}, "pull_request": null}` and the `Deploy` step carries the expected `if`.
- Test-merged against #449 (which also touches `docs.yml`, in the dependency-install steps): auto-merges with no conflicts, both changes present in the result.
- This PR is itself the first exercise of the new trigger — a Docs check should now appear below, where #447 and #449 have none.

## Note

Every PR now pays for a docs build (doxygen plus the pip installs). If that is unwelcome on unrelated changes, the trigger could be narrowed with `paths: [docs/**, .github/workflows/docs.yml]`, at the cost of missing changes that break the docs from elsewhere in the tree. Happy to switch if you would prefer that.

Related: #448, #449.

🤖 Generated with [Claude Code](https://claude.com/claude-code)