### PR TITLE
Fail the docs build on Sphinx warnings, and fix the four it reports

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,4 +54,5 @@ rob_gauss_cov_est
 
 # generated documentation (rebuilt by the docs pipeline)
 docs/src/doxygen_out/
+docs/src/_build/
 CLAUDE.md

--- a/docs/src/Makefile
+++ b/docs/src/Makefile
@@ -3,7 +3,10 @@
 
 # You can set these variables from the command line, and also
 # from the environment for the first two.
-SPHINXOPTS    ?=
+# -W turns warnings into errors, so a broken cross reference or a missing
+# include fails the build instead of shipping to the site. Override on the
+# command line (SPHINXOPTS=) to build a work in progress that still warns.
+SPHINXOPTS    ?= -W
 SPHINXBUILD   ?= sphinx-build
 SOURCEDIR     = .
 BUILDDIR      = _build

--- a/docs/src/_static/js/analytics.js
+++ b/docs/src/_static/js/analytics.js
@@ -1,0 +1,8 @@
+/* Google Analytics (GA4) configuration. The gtag.js loader itself is added by
+   html_js_files in conf.py; this file only pushes the config. */
+window.dataLayer = window.dataLayer || [];
+function gtag() {
+  dataLayer.push(arguments);
+}
+gtag("js", new Date());
+gtag("config", "G-9CY7R8S5N2");

--- a/docs/src/conf.py
+++ b/docs/src/conf.py
@@ -15,7 +15,6 @@
 # sys.path.insert(0, os.path.abspath('.'))
 
 import subprocess
-import sphinx_rtd_theme
 
 # -- Project information -----------------------------------------------------
 
@@ -61,7 +60,6 @@ pygments_style = "default"
 
 # html_theme = 'alabaster'
 html_theme = "sphinx_rtd_theme"
-html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
 
 
 def setup(app):
@@ -72,7 +70,6 @@ html_logo = "_static/scs_logo_transparent.png"
 html_favicon = "_static/favicon.ico"
 html_theme_options = {
     "logo_only": True,
-    "display_version": True,
     #'github_banner': True,
     #'github_user': 'cvxgrp',
     #'github_repo': 'scs',
@@ -80,8 +77,17 @@ html_theme_options = {
     #'logo_name': False,
     #'github_button': False,
     #'github_type': 'star',
-    "analytics_id": "G-9CY7R8S5N2",
 }
+
+# Google Analytics (GA4). Previously configured with the sphinx_rtd_theme
+# "analytics_id" theme option, which the theme deprecated.
+html_js_files = [
+    (
+        "https://www.googletagmanager.com/gtag/js?id=G-9CY7R8S5N2",
+        {"async": "async"},
+    ),
+    "js/analytics.js",
+]
 
 rst_epilog = ".. |version| replace:: %s" % __version__
 

--- a/docs/src/install/python.rst
+++ b/docs/src/install/python.rst
@@ -175,7 +175,8 @@ nuclear norm, :math:`\ell_1` norm, sum-of-largest-eigenvalues), install with:
   python -m pip install -Csetup-args=-Duse_spectral_cones=true .
 
 This requires LAPACK (enabled by default). See
-:ref:`python_spectral_cone_keys` for the cone dict keys.
+:ref:`Spectral cone keys <python_spectral_cone_keys>` for the cone dict
+keys.
 
 Testing
 """""""


### PR DESCRIPTION
Point 1 of #452.

`docs/src/Makefile` passes `$(SPHINXOPTS)` through but never sets it, and `docs.yml` sets nothing, so Sphinx has never run with `-W`. Nothing catches a broken cross reference or a missing include. This sets `SPHINXOPTS ?= -W` and clears the four warnings that were already being emitted and ignored.

## One of them is a live bug

```
install/python.rst:177: WARNING: Failed to create a cross reference.
A title or caption not found: 'python_spectral_cone_keys'
```

The label at `api/python.rst:132` sits on a **bold paragraph**, not a section heading, so the bare `:ref:` form has no title to derive link text from. On the published site today:

```
$ curl -s https://www.cvxgrp.org/scs/install/python.html | grep -o python_spectral_cone_keys
python_spectral_cone_keys
```

The page renders the raw label name instead of a link. Switching to the explicit-title form fixes it and works for any label target, section or not.

## The other three are theme configuration

| Warning | Fix |
|---|---|
| `Calling get_html_theme_path is deprecated` | Drop `html_theme_path` and the `import sphinx_rtd_theme`. The theme is already loaded via `extensions`, so neither is needed. |
| `unsupported theme option 'display_version' given` | Remove it — `sphinx_rtd_theme` does not support it. |
| `The analytics_id option is deprecated` | Load gtag.js via `html_js_files` and configure it from a new `_static/js/analytics.js`. |

**Analytics is preserved, not dropped.** GA4 property `G-9CY7R8S5N2` still loads; the built `index.html` references `googletagmanager.com/gtag/js?id=G-9CY7R8S5N2` exactly as it did before. This route needs no new dependency (the documented replacement, `sphinxcontrib-googleanalytics`, would add one).

Also ignores `docs/src/_build/`, which a bare `make html` leaves untracked. The `docs` target ends with `make clean` so this only bites local builds — which `-W` gives people a reason to run.

## Scope notes

- `-W` catches *broken* references and missing includes. It does **not** report labels that are defined but never used, so it guards against new breakage rather than cleaning up the 8 dead labels in #452 — those need deleting separately (point 5).
- Doxygen's own warnings bypass `-W`, since they come from a `subprocess.call` rather than Sphinx's warning system. Worth knowing that a real one is being ignored right now: `include/aa.h:50: warning: Found unknown command '\in'`. Left for point 3.
- `SPHINXOPTS ?=` stays overridable, so `make html SPHINXOPTS=` still builds a work in progress that only warns.

## Verification

```
$ sphinx-build -W -b html . _build/html    # exit 0, zero warnings
$ make html                                 # build succeeded
```

On master the same build emits 4 warnings. Checked against Sphinx 9.1.0 and Doxygen 1.18.0.

Note this PR is not exercised by CI until #450 lands, since `docs.yml` currently only triggers on push to master.

🤖 Generated with [Claude Code](https://claude.com/claude-code)