### PR TITLE
Pin the docs toolchain and install CI from the requirements file

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -20,7 +20,7 @@ jobs:
           python-version: '3.12'
       - name: Install Python dependencies
         run: |
-          pip install sphinx sphinx-rtd-theme breathe docutils
+          pip install -r docs/src/requirements.txt
       - name: Build docs
         run: |
           cd docs/src && make docs && touch ../.nojekyll

--- a/docs/src/conf.py
+++ b/docs/src/conf.py
@@ -59,7 +59,6 @@ pygments_style = "default"
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
 
-# html_theme = 'alabaster'
 html_theme = "sphinx_rtd_theme"
 html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
 

--- a/docs/src/requirements.txt
+++ b/docs/src/requirements.txt
@@ -1,4 +1,9 @@
-sphinx
-sphinx-rtd-theme
-alabaster
-breathe
+# Pinned so that the published docs are reproducible. Bump deliberately, and
+# rebuild with `-W` (see Makefile) to catch new deprecation warnings before
+# they reach the site.
+#
+# docs.yml installs from this file; keep it as the single source of truth.
+sphinx==9.1.0
+sphinx-rtd-theme==3.1.0
+breathe==4.36.0
+docutils==0.22.4


### PR DESCRIPTION
Point 4 of #452. Reopens the substance of #432, which is closed as completed but did not stick.

## The problem

The docs build is not reproducible, and the two dependency lists disagree with each other:

| | `docs/src/requirements.txt` | `docs.yml` inline install |
|---|---|---|
| `sphinx` | unpinned | unpinned |
| `sphinx-rtd-theme` | unpinned | unpinned |
| `breathe` | unpinned | unpinned |
| `docutils` | **absent** | unpinned |
| `alabaster` | listed | **absent** |

`docs.yml` ignored the requirements file entirely:

```yaml
pip install sphinx sphinx-rtd-theme breathe docutils
```

So the published site is built from whatever the latest releases are on the day, and nobody can reproduce it locally. That is also how the four deprecation warnings in #453 appeared without anyone changing the docs.

## The change

- Pin the four direct dependencies to the versions the docs currently build warning-free with.
- Point `docs.yml` at the file, so there is a single source of truth.
- Drop `alabaster`.

`alabaster` is dropped rather than pinned for two reasons: it was referenced only by a commented-out `html_theme = 'alabaster'` line in `conf.py` (removed here), and it is installed regardless as a transitive dependency of Sphinx —

```
$ pip show alabaster | grep Required-by
Required-by: Sphinx
```

so naming it changed nothing.

## Verification

Built from a clean virtualenv created only from this file:

```
$ python3 -m venv v && v/bin/pip install -r docs/src/requirements.txt
$ v/bin/sphinx-build -b html . out      # exit 0
```

Resolves sphinx 9.1.0, sphinx_rtd_theme 3.1.0, breathe 4.36.0, docutils 0.22.4 — the same set #453 verified as warning-free, so the two compose: after both land the docs build is reproducible *and* `-W` clean.

Test-merged against #453 (which also touches `conf.py` and `docs.yml`): auto-merges with no conflicts.

## Note

Transitive dependencies still float. Pinning the direct set keeps the file reviewable and easy to bump; a full `pip freeze` would be exactly reproducible but noisier to maintain. Happy to switch if you would prefer that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)