### PR TITLE
Narrow the Doxyfile INPUT and stop generating unused LaTeX

### DIFF
--- a/docs/src/Doxyfile
+++ b/docs/src/Doxyfile
@@ -864,7 +864,12 @@ WARN_LOGFILE           =
 # spaces. See also FILE_PATTERNS and EXTENSION_MAPPING
 # Note: If this tag is empty the current directory is searched.
 
-INPUT                  = ../../include ../../src ../../linsys
+INPUT                  = ../../include/scs.h \
+                         ../../include/scs_types.h \
+                         ../../include/glbopts.h \
+                         ../../include/aa.h \
+                         ../../include/aa_stats.h \
+                         ../../include/linsys.h
 
 # This tag can be used to specify the character encoding of the source files
 # that doxygen parses. Internally doxygen uses the UTF-8 encoding. Doxygen uses
@@ -1752,7 +1757,7 @@ EXTRA_SEARCH_MAPPINGS  =
 # If the GENERATE_LATEX tag is set to YES, doxygen will generate LaTeX output.
 # The default value is: YES.
 
-GENERATE_LATEX         = YES
+GENERATE_LATEX         = NO
 
 # The LATEX_OUTPUT tag is used to specify where the LaTeX docs will be put. If a
 # relative path is entered the value of OUTPUT_DIRECTORY will be put in front of


### PR DESCRIPTION
Point 3 of #452.

Doxygen exists here purely as an XML feed for Breathe — `GENERATE_HTML` is already `NO`. Two things were wasteful.

## Unused LaTeX

`GENERATE_LATEX = YES` (line 1755), so every build also produced **70 LaTeX files, 884K**, which nothing consumes and which the `docs` target then deletes anyway with `rm -rf doxygen_out/*`.

## Over-broad INPUT

```
INPUT = ../../include ../../src ../../linsys      # with RECURSIVE = NO
```

That parses 15 headers plus every top-level `src/*.c` and two `linsys` files. Only six contribute to the 16 published Breathe blocks:

| File | Why it is needed |
|---|---|
| `include/scs.h` | the 6 functions and most structs |
| `include/aa.h` | `doxygenfile` whole-file dump |
| `include/linsys.h` | `doxygenfile` dump + `ScsLinSysWork` typedef |
| `include/aa_stats.h` | `AaStats` |
| `include/scs_types.h` | `scs_int` / `scs_float` typedefs in signatures |
| `include/glbopts.h` | the `SCS(x)` macro, during preprocessing |

Result: **XML drops from 2.9M / 48 files to 544K / 16 files, an 81% reduction.**

## Output is unchanged

Verified by diffing the complete rendered site against a master build:

```
$ diff -r base_out narrow_out
Files base_out/.buildinfo and narrow_out/.buildinfo differ
```

`.buildinfo` records build metadata, not content. Everything else is byte-identical, including all three pages that carry Breathe directives — `api/c.html`, `linear_solver/index.html`, `algorithm/acceleration.html`.

## Correction to the issue

#452 speculated this would "cut docs build time noticeably". **It does not** — Doxygen completes in under a second either way on this project. The gain is a smaller, comprehensible intermediate and no dead LaTeX, not speed. Measured rather than assumed.

## Deliberately left alone

- **12 obsolete Doxyfile tags.** Doxygen 1.18 warns about `OUTPUT_TEXT_DIRECTION`, `HTML_TIMESTAMP`, `FORMULA_TRANSPARENT`, `LATEX_SOURCE_CODE`, `LATEX_TIMESTAMP`, `RTF_SOURCE_CODE`, `DOCBOOK_PROGRAMLISTING`, `CLASS_DIAGRAMS`, `DOT_FONTNAME`, `DOT_FONTSIZE`, `DOT_TRANSPARENT`, `DOT_MULTI_TARGETS`. All concern HTML, LaTeX, RTF, DocBook or dot output, none enabled — harmless noise. Removing them (or running `doxygen -u`) would tie the file to a newer Doxygen than CI's `apt-get install doxygen` provides, so it deserves its own PR.
- **`include/aa.h:50: warning: Found unknown command '\in'`** — a genuine docstring bug in the header. That is a source fix, not a docs-config one, and Doxygen's warnings bypass Sphinx's `-W` regardless (they come from a `subprocess.call`).

Independent of #453 and #454 — touches only `docs/src/Doxyfile`.

Checked with Doxygen 1.18.0 and Sphinx 9.1.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)