### PR TITLE
dependabot: watch the pinned docs toolchain

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,7 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "weekly"
+  - package-ecosystem: "pip"
+    directory: "/docs/src" # docs/src/requirements.txt, pinned docs toolchain
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
Follow-up to #454, which pinned the docs toolchain in `docs/src/requirements.txt`. Add a pip ecosystem entry so dependabot proposes bumps, otherwise the pins would rot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)