### PR TITLE
docs: correct skipped-test count in CONTRIBUTING (eight -> nine)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,7 +22,7 @@ make purge
 ```
 
 > **The spectral-cone tests are skipped by default.** `USE_SPECTRAL_CONES`
-> defaults to `0` (see `scs.mk`), so a default `make test` reports eight tests
+> defaults to `0` (see `scs.mk`), so a default `make test` reports nine tests
 > as `skipped` and exercises none of `src/spectral_cones/` — while still
 > printing `ALL TESTS PASSED`. If you touch the log-determinant, nuclear-norm,
 > sum-of-largest or ell1 cone code, build and test with the flag enabled:


### PR DESCRIPTION
`CONTRIBUTING.md` tells contributors that a default `make test` reports **eight**
tests as `skipped`. It reports **nine**.

The nine, from a default (`USE_SPECTRAL_CONES=0`) build:

`exp_design`, `robust_pca`, `graph_partitioning`, `several_sum_largest`,
`several_nuc_cone`, `several_logdet_cones`, `test_ell1_cone`, `test_ell1_and_nuc`,
`test_spectral_metric_updates`

Verified against both suites — each reports `ALL TESTS PASSED`, `Tests run: 62`,
with nine skips:

```
$ ./out/run_tests_direct | grep -c '^skipped$'
9
$ ./out/run_tests_indirect | grep -c '^skipped$'
9
```

One word changed. The rest of the note is unaffected: all nine skipped tests are
spectral-cone tests, so the surrounding claims about `src/spectral_cones/` and the
log-determinant / nuclear-norm / sum-of-largest / ell1 cone code remain accurate.

Closes #459

🤖 Generated with [Claude Code](https://claude.com/claude-code)