### PR TITLE
test: delete the data files the suite leaves in the repo root

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,10 +48,6 @@ python/cover/
 *demo_indirect
 examples/DIMACS/
 
-# data files written by the test suite (write_data_filename)
-hs21_tiny_qp
-rob_gauss_cov_est
-
 # generated documentation (rebuilt by the docs pipeline)
 docs/src/doxygen_out/
 docs/src/_build/

--- a/test/problems/hs21_tiny_qp.h
+++ b/test/problems/hs21_tiny_qp.h
@@ -119,6 +119,7 @@ static const char *hs21_tiny_qp(void) {
   mu_assert("hs21_tiny_qp: SCS failed to produce outputflag SCS_SOLVED",
             success);
 
+  remove("hs21_tiny_qp.csv");
   SCS(free_sol)(sol);
   scs_free(d->A);
   scs_free(d->P);

--- a/test/problems/hs21_tiny_qp_rw.h
+++ b/test/problems/hs21_tiny_qp_rw.h
@@ -124,6 +124,7 @@ static const char *hs21_tiny_qp_rw(void) {
   mu_assert("hs21_tiny_qp: SCS failed to produce outputflag SCS_SOLVED",
             success);
 
+  remove("hs21_tiny_qp");
   SCS(free_data)(d);
   SCS(free_cone)(k);
   SCS(free_sol)(sol);

--- a/test/problems/qafiro_tiny_qp.h
+++ b/test/problems/qafiro_tiny_qp.h
@@ -192,6 +192,7 @@ static const char *qafiro_tiny_qp(void) {
   mu_assert("qafiro_tiny_qp: SCS failed to produce outputflag SCS_SOLVED",
             success);
 
+  remove("qafiro_tiny_qp.csv");
   SCS(free_sol)(sol);
   scs_free(d->A);
   scs_free(d->P);

--- a/test/problems/rob_gauss_cov_est.h
+++ b/test/problems/rob_gauss_cov_est.h
@@ -248,6 +248,8 @@ static const char *rob_gauss_cov_est(void) {
   mu_assert("rob_gauss_cov_est_rw: SCS failed to produce outputflag SCS_SOLVED",
             success);
 
+  remove("rob_gauss_cov_est");
+  remove("rob_gauss_cov_est.csv");
   SCS(free_data)(d);
   SCS(free_cone)(k);
   SCS(free_sol)(sol);

--- a/test/spectral_cones_problems/exp_design.h
+++ b/test/spectral_cones_problems/exp_design.h
@@ -130,6 +130,7 @@ static const char *exp_design(void) {
   mu_assert("exp_design: dual feas error: ", ABS(info.res_dual) < 1e-6);
   mu_assert("exp_design: duality gap error: ", ABS(info.gap) < 1e-6);
 
+  remove("test_exp_design.csv");
   /* kill data */
   scs_free(d->A);
   scs_free(k);

--- a/test/spectral_cones_problems/several_logdet_cones.h
+++ b/test/spectral_cones_problems/several_logdet_cones.h
@@ -211,6 +211,7 @@ static const char *several_logdet_cones(void) {
   mu_assert("several logdet cones: duality gap error ",
             ABS(info.gap) < 5 * 1e-6);
 
+  remove("several_logdet_cone.csv");
   /* kill data */
   scs_free(d->A);
   scs_free(k);


### PR DESCRIPTION
Six tests exercise `write_data_filename` and `log_csv_filename` but never removed what they wrote, so every run of the suite dropped files next to the `Makefile`:

| Leftover | Written by |
| --- | --- |
| `hs21_tiny_qp` | `test/problems/hs21_tiny_qp_rw.h` |
| `hs21_tiny_qp.csv` | `test/problems/hs21_tiny_qp.h` |
| `qafiro_tiny_qp.csv` | `test/problems/qafiro_tiny_qp.h` |
| `rob_gauss_cov_est`, `rob_gauss_cov_est.csv` | `test/problems/rob_gauss_cov_est.h` |
| `test_exp_design.csv` | `test/spectral_cones_problems/exp_design.h` |
| `several_logdet_cone.csv` | `test/spectral_cones_problems/several_logdet_cones.h` |

Both runners work from the source root, so both are affected: the Makefile because the tests are invoked as `out/run_tests_direct`, and CTest because `scs_add_test` sets `WORKING_DIRECTORY` to `CMAKE_CURRENT_SOURCE_DIR`.

## Changes

- `remove()` at the end of each of the six tests, following the existing `remove(fname)` in `test/problems/test_rw_settings.h`. The one-shot `scs()` call closes the CSV log before the test returns, so the file is never removed while open.
- Drop the two `.gitignore` entries that existed only to hide `hs21_tiny_qp` and `rob_gauss_cov_est`. The blanket `*.csv` rule stays — `run_from_file` still lets a caller name a CSV log path.

The working directory deliberately stays the source root: `issue_140`, `issue_220`, `max_ent`, `mpc_bug` and `random_prob` read `test/problems/...` relative to it, so pointing CTest at the build tree would break them.

## Verification

Root confirmed clean after a full run in both configurations:

- default build — 62 tests, all passed
- `USE_SPECTRAL_CONES=1 USE_LAPACK=1` — 71 tests, all passed, which is what actually runs `exp_design` and `several_logdet_cones`

Compiled without new warnings under the existing `-Wall -pedantic -Wstrict-prototypes` flags.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
