### PR TITLE
Test harness: count and name skipped tests, check the total

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,8 +22,9 @@ make purge
 ```
 
 > **The spectral-cone tests are skipped by default.** `USE_SPECTRAL_CONES`
-> defaults to `0` (see `scs.mk`), so a default `make test` reports nine tests
-> as `skipped` and exercises none of `src/spectral_cones/` — while still
+> defaults to `0` (see `scs.mk`), so a default `make test` reports the
+> spectral-cone tests as `skipped` (the summary line at the end of a run counts
+> and names them) and exercises none of `src/spectral_cones/` — while still
 > printing `ALL TESTS PASSED`. If you touch the log-determinant, nuclear-norm,
 > sum-of-largest or ell1 cone code, build and test with the flag enabled:
 >

--- a/test/minunit.h
+++ b/test/minunit.h
@@ -7,7 +7,13 @@
 #define MU_MAX_FAILED_TESTS 256
 extern int tests_run;
 extern int tests_failed;
+extern int tests_skipped;
 extern const char *failed_tests[MU_MAX_FAILED_TESTS];
+extern const char *skipped_tests[MU_MAX_FAILED_TESTS];
+/* Sentinel returned by a test that is compiled out of the current build (see
+ * _SKIP in run_tests.c). Compared by address, so it can never collide with a
+ * real failure message. */
+extern const char *const mu_skipped;
 #define mu_assert_less(message, a, b)                                          \
   do {                                                                         \
     if (a > b) {                                                               \
@@ -29,11 +35,18 @@ extern const char *failed_tests[MU_MAX_FAILED_TESTS];
     scs_printf("*********************************************************\n"); \
     scs_printf("Running test: %s\n", name);                                    \
     const char *message = test();                                              \
-    tests_run++;                                                               \
-    if (message) {                                                             \
-      scs_printf("FAILED: %s: %s\n", name, message);                           \
-      if (tests_failed < MU_MAX_FAILED_TESTS)                                  \
-        failed_tests[tests_failed] = name;                                     \
-      tests_failed++;                                                          \
+    if (message == mu_skipped) {                                               \
+      scs_printf("skipped\n");                                                 \
+      if (tests_skipped < MU_MAX_FAILED_TESTS)                                 \
+        skipped_tests[tests_skipped] = name;                                   \
+      tests_skipped++;                                                         \
+    } else {                                                                   \
+      tests_run++;                                                             \
+      if (message) {                                                           \
+        scs_printf("FAILED: %s: %s\n", name, message);                         \
+        if (tests_failed < MU_MAX_FAILED_TESTS)                                \
+          failed_tests[tests_failed] = name;                                   \
+        tests_failed++;                                                        \
+      }                                                                        \
     }                                                                          \
   } while (0)

--- a/test/run_tests.c
+++ b/test/run_tests.c
@@ -34,15 +34,20 @@
 
 int tests_run = 0;
 int tests_failed = 0;
+int tests_skipped = 0;
 const char *failed_tests[MU_MAX_FAILED_TESTS];
+const char *skipped_tests[MU_MAX_FAILED_TESTS];
+const char *const mu_skipped = "skipped";
 
-/* decrement tests_run since mu_unit will increment it, so this cancels */
+/* Number of mu_run_test calls in all_tests() below. A build flag can compile a
+ * test out, in which case _SKIP replaces it with a stub that reports itself
+ * as skipped, and main() checks that run + skipped == MU_TOTAL_TESTS. A build
+ * that silently loses tests therefore fails instead of printing ALL TESTS
+ * PASSED. Bump this when adding a test. */
+#define MU_TOTAL_TESTS 71
+
 #define _SKIP(problem)                                                         \
-  char *problem(void) {                                                        \
-    scs_printf("skipped\n");                                                   \
-    tests_run--;                                                               \
-    return 0;                                                                  \
-  }
+  static const char *problem(void) { return mu_skipped; }
 
 #if NO_VALIDATE == 0
 #include "problems/test_validation.h"
@@ -186,6 +191,21 @@ static void all_tests(void) {
 int main(void) {
   int i;
   all_tests();
+  scs_printf("Tests run: %d, skipped: %d, total: %d\n", tests_run, tests_skipped,
+             MU_TOTAL_TESTS);
+  if (tests_skipped > 0) {
+    scs_printf("Skipped (compiled out by build flags):");
+    for (i = 0; i < tests_skipped && i < MU_MAX_FAILED_TESTS; ++i) {
+      scs_printf(" %s", skipped_tests[i]);
+    }
+    scs_printf("\n");
+  }
+  if (tests_run + tests_skipped != MU_TOTAL_TESTS) {
+    scs_printf("TEST COUNT MISMATCH: %d run + %d skipped != %d expected "
+               "(update MU_TOTAL_TESTS in test/run_tests.c)\n",
+               tests_run, tests_skipped, MU_TOTAL_TESTS);
+    tests_failed++;
+  }
   if (tests_failed > 0) {
     scs_printf("%d TEST(S) FAILED:\n", tests_failed);
     for (i = 0; i < tests_failed && i < MU_MAX_FAILED_TESTS; ++i) {
@@ -195,7 +215,6 @@ int main(void) {
   } else {
     scs_printf("ALL TESTS PASSED\n");
   }
-  scs_printf("Tests run: %d\n", tests_run);
 
   return tests_failed != 0;
 }


### PR DESCRIPTION
Addresses the skip-tally point from #467 without changing the harness language.

Tests compiled out by a build flag were replaced by a `_SKIP` stub that decremented `tests_run`, so a default build printed `Tests run: 62` with no sign that nine tests were skipped, `CONTRIBUTING.md` had to quote the count by hand (and got it wrong, #459), and a build that silently lost tests still printed `ALL TESTS PASSED`.

Now the stub returns a sentinel the runner recognises, skipped tests are counted and named, and `main()` checks `run + skipped == MU_TOTAL_TESTS`, failing the run on a mismatch. A default build prints:

```
Tests run: 62, skipped: 9, total: 71
Skipped (compiled out by build flags): exp_design robust_pca graph_partitioning several_sum_largest several_nuc_cone several_logdet_cones test_ell1_cone test_ell1_and_nuc test_spectral_metric_updates
ALL TESTS PASSED
```

Assertion macros and all problem headers are unchanged, and `minunit.h` stays valid C for the standalone `rw_settings` binary. `CONTRIBUTING.md` no longer quotes a number.

Verified locally (direct and indirect, all `ALL TESTS PASSED`):

| build | run | skipped |
|---|---|---|
| default | 62 | 9 |
| `USE_SPECTRAL_CONES=1` | 71 | 0 |
| `USE_LAPACK=0` | 56 | 15 |
| `NO_READ_WRITE=1` | 54 | 17 |

Setting `MU_TOTAL_TESTS` to 70 makes the run fail with `TEST COUNT MISMATCH: 62 run + 9 skipped != 70 expected`, and `out/test_rw_settings` still builds warning-free and passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)