### PR TITLE
Test data generator: seed the RNG before the first draw

### DIFF
--- a/test/problem_utils.h
+++ b/test/problem_utils.h
@@ -39,6 +39,11 @@ void gen_random_prob_data(scs_int nnz, scs_int col_nnz, ScsData *d, ScsCone *k,
   A->x = (scs_float *)scs_calloc(nnz, sizeof(scs_float));
   A->n = d->n;
   A->m = d->m;
+  /* seed before the first draw, so that the generated instance is a pure
+   * function of (seed, n, m, nnz, col_nnz, k) rather than of whatever state
+   * the generator was left in by an earlier caller */
+  ran_start(seed);
+
   /* y, s >= 0 and y'*s = 0 */
   for (i = 0; i < m; i++) {
     y[i] = z[i] = rand_scs_float();
@@ -59,7 +64,6 @@ void gen_random_prob_data(scs_int nnz, scs_int col_nnz, ScsData *d, ScsCone *k,
    c = -A'*y
    b = A*x + s
    */
-  ran_start(seed);
   A->p[0] = 0;
   for (j = 0; j < n; j++) { /* column */
     r = 0;


### PR DESCRIPTION
Fixes the seeding bug tschm identified in the follow-up on #467.

`gen_random_prob_data` called `ran_start(seed)` after the loops that draw `y`, `z` and `x`, so only `A` depended on the seed. Everything else depended on the generator state left by the previous caller, or on the RNG's built-in fallback seed for the first caller, which made the generated instances a function of test order. Seeding before the first draw makes each instance a pure function of `(seed, n, m, nnz, col_nnz, k)`.

The tests assert against the optimum built alongside the data, and the checks in `verify_solution_correct` are relative and scale-aware, so the changed instances do not affect any check. Verified locally on direct and indirect: default build 62 run / 9 skipped, all passed; `USE_SPECTRAL_CONES=1` 71 run, all passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)