### PR TITLE
CI: retry the Homebrew BLAS install instead of failing the job

### DIFF
--- a/.github/actions/brew-blas/action.yml
+++ b/.github/actions/brew-blas/action.yml
@@ -1,0 +1,27 @@
+---
+name: Install OpenBLAS and LAPACK
+description: >
+  brew install openblas lapack, retrying the transient formulae.brew.sh
+  outages that would otherwise fail the whole job.
+
+runs:
+  using: composite
+  steps:
+    # The runner image ships a recent formula index, and both formulae are in
+    # it, so HOMEBREW_NO_AUTO_UPDATE skips the formulae.brew.sh API download
+    # that is the part that flakes. The retry covers the bottle downloads.
+    - shell: bash
+      env:
+        HOMEBREW_NO_AUTO_UPDATE: '1'
+        HOMEBREW_NO_ANALYTICS: '1'
+        HOMEBREW_NO_INSTALL_CLEANUP: '1'
+      run: |
+        for attempt in 1 2 3; do
+          if brew install openblas lapack; then
+            exit 0
+          fi
+          echo "brew install failed (attempt ${attempt}/3), retrying in $((attempt * 15))s"
+          sleep $((attempt * 15))
+        done
+        echo "brew install openblas lapack failed after 3 attempts" >&2
+        exit 1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -97,7 +97,7 @@ jobs:
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v7
-      - run: brew update && brew install openblas lapack
+      - uses: ./.github/actions/brew-blas
       - run: make DLONG=${{ matrix.long }} USE_LAPACK=${{ matrix.lapack }}
       - run: make test DLONG=${{ matrix.long }} USE_LAPACK=${{ matrix.lapack }}
       - run: out/run_tests_direct

--- a/.github/workflows/build_spectral.yml
+++ b/.github/workflows/build_spectral.yml
@@ -35,7 +35,7 @@ jobs:
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v7
-      - run: brew update && brew install openblas lapack
+      - uses: ./.github/actions/brew-blas
       # Each `run:` step is a separate shell, so `export` would not persist.
       # -fno-sanitize-recover=all makes UBSan abort on the first report instead of
       # printing and continuing (which would leave the job green).

--- a/.github/workflows/buildpp.yml
+++ b/.github/workflows/buildpp.yml
@@ -35,8 +35,8 @@ jobs:
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v7
+      - uses: ./.github/actions/brew-blas
       - run: |
-          brew install openblas lapack
           export CC=clang++
           echo $CC
           make

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -32,8 +32,8 @@ jobs:
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v7
+      - uses: ./.github/actions/brew-blas
       - run: |
-          brew install openblas lapack
           mkdir out
           export INSTALL_DIR=$PWD/out
           export DYLD_FALLBACK_LIBRARY_PATH=$DYLD_FALLBACK_LIBRARY_PATH:$INSTALL_DIR/lib


### PR DESCRIPTION
A macOS job died in `brew update && brew install openblas lapack` with

```
Error: Failed to download https://formulae.brew.sh/api/internal/packages.arm64_tahoe.jws.json!
```

a transient formulae.brew.sh outage — the three sibling mac jobs in the same run passed with identical steps. Nothing in the code was broken, but the same flake has a path into every macOS job in the repo.

This moves the install into a composite action (`.github/actions/brew-blas`) shared by the four workflows that need BLAS on macOS (`build.yml`, `build_spectral.yml`, `buildpp.yml`, `cmake.yml`). It:

- drops `brew update` and sets `HOMEBREW_NO_AUTO_UPDATE=1`, so the formula-index download that failed is skipped entirely — the runner image already ships an index containing both formulae;
- retries `brew install` three times with backoff, covering bottle-download flakes as well.

🤖 Generated with [Claude Code](https://claude.com/claude-code)