### PR TITLE
CI: build against minimal CUDA redistributables, covering #322

### DIFF
--- a/.github/workflows/gpu.yml
+++ b/.github/workflows/gpu.yml
@@ -75,9 +75,10 @@ jobs:
           crt=cuda_crt
           python3 -c "import json; exit(0 if 'cuda_crt' in json.load(open('redist.json')) else 1)" || crt=cuda_nvcc
           echo "crt headers come from $crt"
+          # cuda_cccl supplies <nv/target>, which cuda_fp16.h reaches for.
           # libnvjitlink is not used directly, but libcusparse.so records it as
           # a dependency and the linker has to resolve it.
-          for pkg in cuda_cudart libcublas libcusparse libnvjitlink "$crt"; do
+          for pkg in cuda_cudart cuda_cccl libcublas libcusparse libnvjitlink "$crt"; do
             path=$(python3 -c "import json; print(json.load(open('redist.json'))['$pkg']['linux-x86_64']['relative_path'])")
             echo "==> $pkg"
             curl -sSfL "$base/$path" | tar -xJ --strip-components=1 -C "$prefix"

--- a/.github/workflows/gpu.yml
+++ b/.github/workflows/gpu.yml
@@ -40,3 +40,56 @@ jobs:
           "${CUDA_PATH}/bin/nvcc" --version
           make cudss CUDA_PATH="${CUDA_PATH}"
       # - run: out/run_tests_cudss           # gpus not available yet
+
+  # Regression test for cvxgrp/scs#322. linsys/gpu/*.c are compiled by $(CC),
+  # not by nvcc, so they include the CUDA headers directly and driver_types.h
+  # pulls in crt/host_defines.h. Up to CUDA 12 those crt headers shipped inside
+  # cuda_nvcc; CUDA 13 split them into a separate cuda_crt redistributable, so
+  # a package build that installs only the runtime components dies with
+  #   driver_types.h:59: fatal error: crt/host_defines.h: No such file
+  # The `linux` job above installs the full apt toolkit and so never sees this.
+  # Here we assemble the minimal component set from the redistributable
+  # tarballs -- the way downstream packagers build SCS -- on both sides of the
+  # split. Bump the 13.x pin when a newer CUDA reshuffles the layout again.
+  cuda-redist:
+    strategy:
+      fail-fast: false
+      matrix:
+        cuda: ['12.6.0', '13.0.0']
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v7
+      - run: sudo apt-get update && sudo apt-get install -y libopenblas-dev liblapack-dev
+
+      - name: Assemble CUDA ${{ matrix.cuda }} from redistributables
+        run: |
+          set -euo pipefail
+          base=https://developer.download.nvidia.com/compute/cuda/redist
+          prefix="$PWD/cuda"
+          mkdir -p "$prefix"
+          curl -sSfL -o redist.json "$base/redistrib_${{ matrix.cuda }}.json"
+          # cuda_crt only exists from CUDA 13 on; before that the crt headers
+          # were part of cuda_nvcc.
+          crt=cuda_crt
+          python3 -c "import json; exit(0 if 'cuda_crt' in json.load(open('redist.json')) else 1)" || crt=cuda_nvcc
+          echo "crt headers come from $crt"
+          # libnvjitlink is not used directly, but libcusparse.so records it as
+          # a dependency and the linker has to resolve it.
+          for pkg in cuda_cudart libcublas libcusparse libnvjitlink "$crt"; do
+            path=$(python3 -c "import json; print(json.load(open('redist.json'))['$pkg']['linux-x86_64']['relative_path'])")
+            echo "==> $pkg"
+            curl -sSfL "$base/$path" | tar -xJ --strip-components=1 -C "$prefix"
+          done
+          echo "CUDA_PATH=$prefix" >> "$GITHUB_ENV"
+
+      - name: Check the headers host-compiled sources need are present
+        run: |
+          # The exact file whose absence produced the error in #322.
+          test -f "$CUDA_PATH/include/crt/host_defines.h"
+
+      - run: CFLAGS=-Werror=implicit-function-declaration make gpu CUDA_PATH="$CUDA_PATH"
+      - run: make test_gpu CUDA_PATH="$CUDA_PATH"
+      # Running out/run_tests_gpu_indirect needs a device; only the build is
+      # checked here, which is all #322 was about.

--- a/docs/src/install/c.rst
+++ b/docs/src/install/c.rst
@@ -215,6 +215,21 @@ binaries in the out folder corresponding to the GPU version.  Note that the GPU
   make gpu DLONG=0
   out/run_tests_gpu_indirect
 
+The GPU sources are compiled by the host C compiler rather than by
+:code:`nvcc`, so they include the CUDA headers directly.  This means the
+:code:`crt` headers must be present alongside the runtime: up to CUDA 12 they
+were part of the :code:`cuda_nvcc` component, whereas CUDA 13 moved them into a
+separate :code:`cuda_crt` component.  A partial installation that omits it
+fails with
+
+.. code:: text
+
+  driver_types.h:59:30: fatal error: crt/host_defines.h: No such file or directory
+
+Installing the full CUDA toolkit pulls the component in automatically; only
+builds that pick individual components (distribution packaging, for instance)
+need to request it explicitly.
+
 Finally, to compile and test the :ref:`cuDSS solver <cudss_solver>` you need to
 have CUDA toolkit, the :code:`nvcc` compiler, and `cuDSS
 <https://developer.nvidia.com/cudss>`_ library installed.  Then set


### PR DESCRIPTION
Refs #322.

## What #322 actually is

SCS compiles `linsys/gpu/*.c` with `$(CC)` rather than `nvcc` (`Makefile:236-240`), so those sources include the CUDA headers directly and `driver_types.h` pulls in `crt/host_defines.h`. Up to CUDA 12 the `crt/` headers shipped inside `cuda_nvcc`; **CUDA 13 split them into a separate `cuda_crt` redistributable**, confirmed against NVIDIA's manifests:

| | `cuda_nvcc` ships `include/crt/` | `cuda_crt` exists |
|---|---|---|
| 12.6.20 | yes | no |
| 13.0.48 | **no** | **yes** |

Hence the reported failure in a component-wise install:

```
driver_types.h:59:30: fatal error: crt/host_defines.h: No such file or directory
```

## Why the existing GPU job cannot catch it

It already builds with CUDA 13.2 — that is `Jimver/cuda-toolkit`'s current default — and is green, because the apt metapackage pulls `cuda-crt-*` in transitively. A CUDA-version matrix leg would add a passing job and no signal. The bug only exists for installs that pick individual components, which is how downstream packagers build.

## The test

New `cuda-redist` job assembling CUDA from the redistributable tarballs the way a packager does, over `12.6.0` and `13.0.0` — both sides of the split. The crt provider is resolved per version (`cuda_crt` on 13.x, falling back to `cuda_nvcc` on 12.x), and the job asserts `crt/host_defines.h` is present before building, so a future reshuffle fails here with a pointed message rather than as a compiler error downstream. Then `make gpu` and `make test_gpu`. Running the binary needs a device, so this is build-only — which is all #322 was about.

Writing it turned up a **second** missing component: `make gpu` then failed with

```
cuda_fp16.h:4492:10: fatal error: nv/target: No such file or directory
```

`<nv/target>` comes from `cuda_cccl`, which a runtime-only install also does not pull in. So the full header closure for host-compiled GPU sources is `cuda_cudart`, `cuda_cccl`, the crt provider, `libcublas`, `libcusparse` (plus `libnvjitlink`, which `libcusparse.so` records as a dependency for the linker to resolve).

Both legs pass, in 1m34s and 2m7s — cheaper than the existing `linux` job, since the tarballs stream straight through `tar` and are never stored.

Also documents the requirement next to `make gpu` in `docs/src/install/c.rst`, since a full-toolkit install hides it.

For the packaging question in #322: the CUDA 13 build works, it just needs `cuda_crt` and `cuda_cccl` added to the component list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
