### PR TITLE
docs: versioned PDF user guide built from the Sphinx sources

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -35,12 +35,13 @@ jobs:
       # pdflatex (see `make guide` in docs/src/Makefile) and published next to
       # the site as scs_user_guide.pdf. texlive-latex-extra carries the
       # packages Sphinx's LaTeX output needs (tabulary, titlesec, ...) and
-      # texlive-fonts-recommended the TeX Gyre fonts it uses.
+      # tex-gyre the TeX Gyre fonts it uses, which Ubuntu ships separately
+      # from texlive-fonts-recommended.
       - name: Install TeX
         run: |
           sudo apt-get install -y --no-install-recommends \
             texlive-latex-base texlive-latex-recommended texlive-latex-extra \
-            texlive-fonts-recommended
+            texlive-fonts-recommended tex-gyre
       - name: Build PDF user guide
         run: |
           cd docs/src && make guide && cp _build/latex/scs_user_guide.pdf ../

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -31,6 +31,19 @@ jobs:
       - name: Build docs
         run: |
           cd docs/src && make docs && touch ../.nojekyll
+      # The PDF user guide is rendered from the same Sphinx sources through
+      # pdflatex (see `make guide` in docs/src/Makefile) and published next to
+      # the site as scs_user_guide.pdf. texlive-latex-extra carries the
+      # packages Sphinx's LaTeX output needs (tabulary, titlesec, ...) and
+      # texlive-fonts-recommended the TeX Gyre fonts it uses.
+      - name: Install TeX
+        run: |
+          sudo apt-get install -y --no-install-recommends \
+            texlive-latex-base texlive-latex-recommended texlive-latex-extra \
+            texlive-fonts-recommended
+      - name: Build PDF user guide
+        run: |
+          cd docs/src && make guide && cp _build/latex/scs_user_guide.pdf ../
       # Deploying needs a writable GITHUB_TOKEN, which forks do not get by
       # default, and a fork publishing its own copy of the docs is not wanted
       # anyway -- so restrict the deploy to a push on the canonical repo. On

--- a/docs/src/Makefile
+++ b/docs/src/Makefile
@@ -46,7 +46,7 @@ SCSROOT    = ../..
 # "build the Python extension" and adds -DPYTHON to the C flags.
 DOCS_PYTHON ?= python3
 
-.PHONY: example_outputs check_example_deps
+.PHONY: example_outputs check_example_deps guide
 
 check_example_deps:
 	@$(DOCS_PYTHON) -c "import scs, numpy, scipy, cvxpy" 2>/dev/null || { \
@@ -67,6 +67,21 @@ example_outputs: check_example_deps
 	@$(CC) -I$(SCSROOT)/include -o $(EXAMPLEDIR)/qp.out $(EXAMPLEDIR)/qp.c \
 		$(SCSROOT)/out/libscsdir.a -lm -llapack -lblas
 	@( cd $(EXAMPLEDIR) && ./qp.out > qp.c.out )
+
+# --- PDF user guide ---------------------------------------------------------
+#
+# The same sources as the site, rendered through Sphinx's LaTeX builder, so the
+# guide cannot drift from the site; the release number in conf.py appears on
+# the title page. pdflatex is run directly (three passes, as for any LaTeX
+# document with a table of contents) rather than through latexmk, so the only
+# requirement beyond the docs toolchain is a TeX installation.
+guide: example_outputs
+	@$(SPHINXBUILD) -b latex "$(SOURCEDIR)" "$(BUILDDIR)/latex" $(SPHINXOPTS) $(O)
+	@cd "$(BUILDDIR)/latex" && for pass in 1 2 3; do \
+		pdflatex -interaction=nonstopmode -halt-on-error scs_user_guide.tex > pdflatex.out 2>&1 || \
+			{ tail -40 pdflatex.out; exit 1; }; \
+	done
+	@echo "PDF user guide written to $(BUILDDIR)/latex/scs_user_guide.pdf"
 
 docs: example_outputs
 	@make html

--- a/docs/src/algorithm/equilibration.rst
+++ b/docs/src/algorithm/equilibration.rst
@@ -116,7 +116,7 @@ Primal residual:
 
 .. math::
 
-  r_p = \|A x + s - b\| = (1/\sigma) \| D^{-1} (\hat A \hat x + \hat s + \hat b)\|
+  r_p = \|A x + s - b\| = (1/\sigma) \| D^{-1} (\hat A \hat x + \hat s - \hat b)\|
 
 Dual residual:
 

--- a/docs/src/algorithm/index.rst
+++ b/docs/src/algorithm/index.rst
@@ -15,7 +15,27 @@ Algorithm
 
 
 SCS applies Douglas-Rachford splitting to a homogeneous embedding
-of the quadratic cone program. The high level algorithm is as follows,
+of the quadratic cone program. The embedding collects the primal and dual
+variables and a scalar :math:`\tau \geq 0` (which multiplies :math:`b` and
+:math:`c`) into :math:`u = (x, y, \tau) \in \mathbf{R}^{n+m+1}`, and asks for
+:math:`u \in \mathcal{C}_+` with :math:`0 \in \mathcal{Q}u + N_{\mathcal{C}_+}(u)`,
+where
+
+.. math::
+  \mathcal{Q} = \begin{bmatrix} P & A^\top & c \\ -A & 0 & b \\ -c^\top & -b^\top & 0 \end{bmatrix},
+  \qquad
+  \mathcal{C}_+ = \mathbf{R}^n \times \mathcal{K}^* \times \mathbf{R}_+,
+
+:math:`N_{\mathcal{C}_+}` is the normal cone of :math:`\mathcal{C}_+`, and
+:math:`\mathcal{Q}` is the sum of a positive semidefinite and a skew-symmetric
+matrix, hence monotone. Writing :math:`v = \mathcal{Q} u = (r, s, \kappa)`, a
+solution has :math:`r = 0`, :math:`s = b\tau - Ax \in \mathcal{K}`,
+:math:`s \perp y` and :math:`\tau \kappa = 0`. If :math:`\tau > 0` then
+:math:`(x, y, s) / \tau` satisfies the :ref:`optimality conditions
+<optimality>`; if :math:`\tau = 0` and :math:`\kappa > 0` then :math:`x` or
+:math:`y` is a :ref:`certificate of infeasibility <infeasibility>`. A solution
+of the embedding always exists, so infeasibility is detected without any
+special handling. The high level algorithm is as follows,
 from an initial :math:`w^0` for :math:`k=0,1,\ldots` do
 
 .. math::

--- a/docs/src/algorithm/scale.rst
+++ b/docs/src/algorithm/scale.rst
@@ -76,13 +76,28 @@ is determined by :code:`TAU_FACTOR` in the code defined in :code:`glbopts.h`.
 Root-plus function
 ------------------
 
-Finally, the :code:`root_plus` function is modified to be the solution
-of the following quadratic equation:
+The linear solve :math:`\tilde u^{k+1} = (R + \mathcal{Q})^{-1} R w^k` has size
+:math:`n + m + 1` and a dense last row and column (from :math:`b` and :math:`c`).
+SCS reduces it to a fixed sparse system of size :math:`n + m` plus a scalar
+quadratic. Split :math:`w^k = (\mu^k, \eta^k)` with :math:`\mu^k \in
+\mathbf{R}^{n+m}` and :math:`\eta^k \in \mathbf{R}`, let :math:`R_{-1}` be the
+leading :math:`(n+m)` block of :math:`R` and :math:`M = \begin{bmatrix} P &
+A^\top \\ -A & 0 \end{bmatrix}`. Then the first :math:`n+m` entries of
+:math:`\tilde u^{k+1}` are :math:`p^k - \tau^{k+1} g`, where
 
 .. math::
-  \tau^2 (d + r^\top R_{-1} r) + \tau (r^\top R_{-1} \mu^k - 2 r^\top R_{-1} p^k - d \eta^k) + p^k R_{-1} (p^k - \mu^k) = 0,
+  p^k = (R_{-1} + M)^{-1} R_{-1} \mu^k, \qquad
+  g = (R_{-1} + M)^{-1} \begin{bmatrix} c \\ -b \end{bmatrix},
 
-where :math:`R_{-1}` corresponds to the first :math:`n+m` entries of :math:`R`.
+and :math:`\tau^{k+1}` is the positive root of the quadratic
+
+.. math::
+  \tau^2 (d + g^\top R_{-1} g) + \tau (g^\top R_{-1} \mu^k - 2 g^\top R_{-1} p^k - d \eta^k) + p^{k\top} R_{-1} (p^k - \mu^k) = 0,
+
+which is the :code:`root_plus` function in :code:`src/scs.c`. The vector
+:math:`g` depends only on the data and :math:`R`, so it is computed once (and
+again whenever :math:`R` changes) and cached; each iteration then costs one
+solve for :math:`p^k`, a few weighted inner products, and the root-find.
 Other than when computing :math:`\kappa` (which does not affect the algorithm)
 this is the *only* place where :math:`d` appears, so we have a lot of
 flexibility in how to choose it and it can even change from iteration to
@@ -162,11 +177,11 @@ Now consider
   \beta = \left(\prod_{i=0}^{l-1} \frac{\hat r^{k-i}_p}{\hat r^{k-i}_d}\right)^{1/l}
 
 ie, :math:`\beta` corresponds to the geometric mean of the ratio of the relative
-residuals across the last :math:`l` iterations. If this number is larger than a
-constant (eg, 3) or smaller than another constant (eg, 1/3) *and* if sufficient
-iterations have passed since the last update (eg, 100, as determined by
-:code:`RESCALING_MIN_ITERS`) then an update of the :code:`scale` parameter is
-triggered:
+residuals across the last :math:`l` iterations. If this number is larger than
+:math:`10` or smaller than :math:`1/10` (the code tests :math:`\sqrt{\beta}`
+against :math:`\sqrt{10}`) *and* if sufficient iterations have passed since the
+last update (100 by default, as determined by :code:`RESCALING_MIN_ITERS`) then
+an update of the :code:`scale` parameter is triggered:
 
 .. math::
    \mbox{scale}^+ = \sqrt{\beta}\ \mbox{scale}

--- a/docs/src/api/c.rst
+++ b/docs/src/api/c.rst
@@ -51,8 +51,10 @@ The relevant input structs required by API are as follows.
 Data
 ^^^^
 
-.. doxygenstruct:: ScsData
-   :members:
+.. literalinclude:: ../../../include/scs.h
+   :language: c
+   :start-at: /** Struct containing problem data.
+   :end-at: } ScsData;
 
 .. _ScsMatrix:
 
@@ -62,30 +64,34 @@ Data Matrices
 The matrices must be in `Compressed Sparse Column (CSC) format <https://people.sc.fsu.edu/~jburkardt/data/cc/cc.html>`_ using zero-based indexing.
 See :ref:`matrices` for more details on what SCS expects.
 
-.. doxygenstruct:: ScsMatrix
-   :members:
+.. literalinclude:: ../../../include/scs.h
+   :language: c
+   :start-at: /** This defines the data matrices
+   :end-at: } ScsMatrix;
 
 .. _ScsCone:
 
 Cone
 ^^^^
 
-The fields are documented in the :ref:`cones` table; the struct itself is:
+The fields are documented in the :ref:`cones` table; the declaration is:
 
-.. doxygenstruct:: ScsCone
-   :members:
-   :outline:
+.. literalinclude:: ../../../include/scs.h
+   :language: c
+   :start-at: /** Cone data.
+   :end-at: } ScsCone;
 
 .. _ScsSettings:
 
 Settings
 ^^^^^^^^
 
-Each field is documented in the :ref:`settings` table; the struct itself is:
+Each field is documented in the :ref:`settings` table; the declaration is:
 
-.. doxygenstruct:: ScsSettings
-   :members:
-   :outline:
+.. literalinclude:: ../../../include/scs.h
+   :language: c
+   :start-at: /** Struct containing all settings.
+   :end-at: } ScsSettings;
 
 Output Types
 ------------
@@ -103,22 +109,27 @@ solver, then the Solution struct is also used as an input to specify the
 warm-start points (see :ref:`warm_start`).
 
 
-.. doxygenstruct:: ScsSolution
-   :members:
+.. literalinclude:: ../../../include/scs.h
+   :language: c
+   :start-at: /** Contains primal-dual solution arrays
+   :end-at: } ScsSolution;
 
 .. _ScsInfo:
 
 Info
 ^^^^^
 
-Each field is documented in the :ref:`info` table; the struct itself is:
+Each field is documented in the :ref:`info` table; the declaration is:
 
-.. doxygenstruct:: ScsInfo
-   :members:
-   :outline:
+.. literalinclude:: ../../../include/scs.h
+   :language: c
+   :start-at: /** Contains information about the solve run
+   :end-at: } ScsInfo;
 
-.. doxygenstruct:: AaStats
-   :members:
+.. literalinclude:: ../../../include/aa_stats.h
+   :language: c
+   :start-at: typedef struct {
+   :end-at: } AaStats;
 
 Workspace
 ---------

--- a/docs/src/api/c.rst
+++ b/docs/src/api/c.rst
@@ -70,20 +70,22 @@ See :ref:`matrices` for more details on what SCS expects.
 Cone
 ^^^^
 
-See :ref:`cones` for more details.
+The fields are documented in the :ref:`cones` table; the struct itself is:
 
 .. doxygenstruct:: ScsCone
    :members:
+   :outline:
 
 .. _ScsSettings:
 
 Settings
 ^^^^^^^^
 
-See :ref:`settings` for details on each of these.
+Each field is documented in the :ref:`settings` table; the struct itself is:
 
 .. doxygenstruct:: ScsSettings
-  :members:
+   :members:
+   :outline:
 
 Output Types
 ------------
@@ -109,10 +111,11 @@ warm-start points (see :ref:`warm_start`).
 Info
 ^^^^^
 
-See :ref:`info` for details on each of these.
+Each field is documented in the :ref:`info` table; the struct itself is:
 
 .. doxygenstruct:: ScsInfo
    :members:
+   :outline:
 
 .. doxygenstruct:: AaStats
    :members:

--- a/docs/src/api/compile_flags.rst
+++ b/docs/src/api/compile_flags.rst
@@ -11,8 +11,9 @@ executing, e.g., :code:`make DLONG=1`, to set the :code:`DLONG` flag to True.
 
 
 .. list-table::
-   :widths: 25 25 25 25
+   :widths: 30 40 15 15
    :header-rows: 1
+   :class: longtable
 
    * - Name
      - Description

--- a/docs/src/api/cones.rst
+++ b/docs/src/api/cones.rst
@@ -83,7 +83,7 @@ The following cones are available when spectral cone support is enabled.
 
 .. list-table::
    :header-rows: 1
-   :widths: 16 36 32 16
+   :widths: 15 30 31 24
 
    * - Name
      - Description
@@ -92,19 +92,19 @@ The following cones are available when spectral cone support is enabled.
    * - Log-determinant cone
      - :math:`\{(t, v, X) \mid t \leq v \log\det(X/v),\; v > 0,\; X \succ 0 \}`
      - :code:`d` array of matrix dimensions with :code:`dsize` elements, each :math:`d_i = n_i` where :math:`X \in \mathbf{R}^{n_i \times n_i}`.
-     - :math:`\displaystyle \sum_{i=1}^{\text{dsize}} \left(\frac{d_i(d_i+1)}{2} + 2\right)`
+     - :math:`\sum_{i=1}^{\text{dsize}} \left(\frac{d_i(d_i+1)}{2} + 2\right)`
    * - Nuclear norm cone
      - :math:`\{(t, X) \mid \|X\|_* \leq t \}`
      - :code:`nuc_m`, :code:`nuc_n` arrays of matrix dimensions with :code:`nucsize` elements. :math:`X \in \mathbf{R}^{m_i \times n_i}`.
-     - :math:`\displaystyle \sum_{i=1}^{\text{nucsize}} (m_i n_i + 1)`
+     - :math:`\sum_{i=1}^{\text{nucsize}} (m_i n_i + 1)`
    * - :math:`\ell_1` norm cone
      - :math:`\{(t, x) \mid \|x\|_1 \leq t \}`
      - :code:`ell1` array of vector dimensions with :code:`ell1_size` elements.
-     - :math:`\displaystyle \sum_{i=1}^{\text{ell1\_size}} (\text{ell1}_i + 1)`
+     - :math:`\sum_{i=1}^{\text{ell1\_size}} (\text{ell1}_i + 1)`
    * - Sum-of-largest-eigenvalues cone
      - :math:`\{(t, X) \mid \sum_{i=1}^{k} \lambda_i(X) \leq t \}`
      - :code:`sl_n`, :code:`sl_k` arrays of matrix dimensions and :math:`k` values with :code:`sl_size` elements.
-     - :math:`\displaystyle \sum_{i=1}^{\text{sl\_size}} \left(\frac{n_i(n_i+1)}{2} + 1\right)`
+     - :math:`\sum_{i=1}^{\text{sl\_size}} \left(\frac{n_i(n_i+1)}{2} + 1\right)`
 
 
 **Note**:

--- a/docs/src/api/cones.rst
+++ b/docs/src/api/cones.rst
@@ -8,6 +8,7 @@ The cone :math:`\mathcal{K}` can be any Cartesian product of the following primi
 
 .. list-table::
    :header-rows: 1
+   :widths: 16 36 32 16
 
    * - Name
      - Description
@@ -82,6 +83,7 @@ The following cones are available when spectral cone support is enabled.
 
 .. list-table::
    :header-rows: 1
+   :widths: 16 36 32 16
 
    * - Name
      - Description

--- a/docs/src/api/info.rst
+++ b/docs/src/api/info.rst
@@ -7,7 +7,7 @@ the following fields.
 
 
 .. list-table::
-   :widths: 15 15 70
+   :widths: 24 12 64
    :header-rows: 1
 
    * - Name

--- a/docs/src/api/settings.rst
+++ b/docs/src/api/settings.rst
@@ -7,8 +7,9 @@ These settings control how SCS behaves during a solve.
 They are set in the :ref:`ScsSettings <ScsSettings>` struct.
 
 .. list-table::
-   :widths: 20 20 20 20 20
+   :widths: 28 10 38 12 12
    :header-rows: 1
+   :class: longtable
 
    * - Name
      - Type

--- a/docs/src/conf.py
+++ b/docs/src/conf.py
@@ -100,10 +100,11 @@ html_static_path = ["_static"]
 #
 # `make guide` builds docs/src/_build/latex/scs_user_guide.pdf from the same
 # sources as the HTML site, so the two cannot drift; the release number above
-# appears on the title page, which is what versions the guide.
+# appears on the title page, which is what versions the guide. Its master
+# document, guide/index.rst, selects the pages the PDF contains.
 latex_engine = "pdflatex"
 latex_documents = [
-    ("index", "scs_user_guide.tex", "SCS User Guide", author, "manual"),
+    ("guide/index", "scs_user_guide.tex", "SCS User Guide", author, "manual"),
 ]
 latex_logo = "_static/scs_logo_transparent.png"
 latex_show_urls = "footnote"

--- a/docs/src/conf.py
+++ b/docs/src/conf.py
@@ -95,3 +95,32 @@ breathe_default_project = "scs"
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
 html_static_path = ["_static"]
+
+# -- Options for the PDF user guide (LaTeX builder) ---------------------------
+#
+# `make guide` builds docs/src/_build/latex/scs_user_guide.pdf from the same
+# sources as the HTML site, so the two cannot drift; the release number above
+# appears on the title page, which is what versions the guide.
+latex_engine = "pdflatex"
+latex_documents = [
+    ("index", "scs_user_guide.tex", "SCS User Guide", author, "manual"),
+]
+latex_logo = "_static/scs_logo_transparent.png"
+latex_show_urls = "footnote"
+latex_elements = {
+    "papersize": "letterpaper",
+    "pointsize": "11pt",
+    # the site's front page repeats the title; the PDF gets a table of contents
+    "tableofcontents": r"\sphinxtableofcontents",
+    # pdflatex cannot typeset these characters on its own; they appear in code
+    # comments (the JavaScript example, the aa.h docstrings) that reach the
+    # PDF through literalinclude and Breathe.
+    "preamble": r"""
+\DeclareUnicodeCharacter{2208}{\ensuremath{\in}}
+\DeclareUnicodeCharacter{2264}{\ensuremath{\leq}}
+\DeclareUnicodeCharacter{2265}{\ensuremath{\geq}}
+\DeclareUnicodeCharacter{2192}{\ensuremath{\rightarrow}}
+\DeclareUnicodeCharacter{00D7}{\ensuremath{\times}}
+\DeclareUnicodeCharacter{03B3}{\ensuremath{\gamma}}
+""",
+}

--- a/docs/src/conf.py
+++ b/docs/src/conf.py
@@ -123,5 +123,23 @@ latex_elements = {
 \DeclareUnicodeCharacter{2192}{\ensuremath{\rightarrow}}
 \DeclareUnicodeCharacter{00D7}{\ensuremath{\times}}
 \DeclareUnicodeCharacter{03B3}{\ensuremath{\gamma}}
+% Sphinx typesets every struct member and function as its own list
+% environment with generous vertical padding, which stretches the C API
+% reference over pages. Tighten it: no extra space above or below each
+% entry, and none between a signature and its one-line description.
+\makeatletter
+\renewenvironment{fulllineitems}{%
+  \begin{list}{}{\labelwidth \leftmargin
+                 \rightmargin \z@ \topsep \z@ \partopsep \z@
+                 \itemsep \z@ \parsep \z@
+                 \let\makelabel=\py@itemnewline}%
+}{\end{list}}
+\makeatother
+% Tables in a manual read better a size down, and the settings and compile
+% flag tables have long monospace names that do not fit a column at 11pt.
+\usepackage{etoolbox}
+\AtBeginEnvironment{longtable}{\small}
+\AtBeginEnvironment{tabulary}{\small}
+\AtBeginEnvironment{tabular}{\small}
 """,
 }

--- a/docs/src/examples/javascript.rst
+++ b/docs/src/examples/javascript.rst
@@ -122,8 +122,10 @@ Next, we will consider a problem involving maximum entropy. Given a vector
 over the unit simplex.
 
 .. math::
+  :nowrap:
+
   \begin{align*}
-	  \text{minimize} \quad & \sum_{i = 1}^n x_i \log x_i - \langle y, x \rangle \\
+    \text{minimize} \quad & \sum_{i = 1}^n x_i \log x_i - \langle y, x \rangle \\
     \text{subject to} \quad & \sum_{i = 1}^n x_i = 1 \\
     & x \geq 0
   \end{align*}
@@ -134,6 +136,8 @@ This problem can be formulated using the :ref:`(primal) exponential cone <cones>
 defined as 
 
 .. math::
+  :nowrap:
+
   \begin{align*}
     \mathcal{K}_{\text{exp}} &= \{ (x,y,z) \in \mathbf{R}^3 \mid y e^{x/y} \leq z, y>0  \} \\
     &= \{ (x,y,z) \in \mathbf{R}^3 \mid y \log(z/y) \geq x, y>0, z>0 \}
@@ -142,6 +146,8 @@ defined as
 Our formulation is then:
 
 .. math::
+  :nowrap:
+
   \begin{align*}
     \text{minimize} \quad & \sum_{i = 1}^n t_i - \langle y, x \rangle \\
     \text{subject to} \quad & \sum_{i = 1}^n x_i = 1 \\

--- a/docs/src/guide/api.rst
+++ b/docs/src/guide/api.rst
@@ -1,0 +1,24 @@
+:orphan:
+
+API
+===
+
+SCS takes data :math:`P, A, b, c, \mathcal{K}` and produces primal-dual
+:ref:`optimal <optimality>` points :math:`(x^\star, y^\star, s^\star)` or a
+certificate of primal or dual :ref:`infeasibility`. The pages below describe
+the supported cones, the matrix input format, the settings, the information
+returned about a solve and the exit flags, followed by the C and Python
+interfaces. The other language interfaces are documented on the website at
+https://www.cvxgrp.org/scs/api/.
+
+.. toctree::
+   :maxdepth: 2
+
+   /api/cones
+   /api/matrices
+   /api/settings
+   /api/info
+   /api/exit_flags
+   /api/compile_flags
+   /api/c
+   /api/python

--- a/docs/src/guide/best_practices.rst
+++ b/docs/src/guide/best_practices.rst
@@ -1,0 +1,178 @@
+.. This chapter is a first draft written for maintainer review. Every
+   recommendation below should be checked by someone who knows the solver
+   better than its documentation does before it ships.
+
+.. _best_practices:
+
+Best practices
+==============
+
+SCS is a first-order method. That gives it its strengths (it scales, it
+detects infeasibility, it warm-starts, and it handles every cone the same way)
+and its one weakness: it converges quickly to modest accuracy and slowly to
+high accuracy. Most of the advice below follows from that single fact.
+
+Scale your problem
+------------------
+
+The single most effective thing you can do for SCS is to hand it well-scaled
+data. Aim for the nonzero entries of :math:`A`, :math:`P`, :math:`b` and
+:math:`c` to be within a few orders of magnitude of one another, ideally around
+one. Choose units for your variables and constraints with that in mind: a
+constraint expressed in millimetres next to one expressed in kilometres will
+hurt.
+
+SCS :ref:`equilibrates <equilibration>` the data before solving (the
+:code:`normalize` setting, on by default) and adapts its internal metric during
+the solve (:code:`adaptive_scale` and :code:`adaptive_diag_scale`, both on by
+default). These fix moderate scaling problems automatically, and you should
+leave them on. They cannot fix extreme ones: if your data spans ten orders of
+magnitude, rescale it yourself first.
+
+If you have turned :code:`normalize` off for some reason, the :code:`scale`
+setting becomes the main knob; values between :code:`0.01` and :code:`10`
+cover most problems.
+
+Choose tolerances deliberately
+------------------------------
+
+The stopping criteria are relative (see :ref:`termination <termination>`), so
+:code:`eps_abs` and :code:`eps_rel` are dimensionless. The defaults of
+:code:`1e-4` give a solution that is accurate to roughly four digits in the
+residuals, which is enough for most applications, and SCS typically reaches it
+in a few hundred to a few thousand iterations.
+
+Tighter tolerances cost more than you might expect. Each additional decade of
+accuracy can cost a multiple of the iterations of the last one, particularly on
+degenerate problems where the optimal set is not a single point. Before
+tightening, ask whether you need the extra digits in the solution or only a
+smaller objective error: the objective converges faster than the iterates. If
+you do need :code:`1e-8` or better on a small problem, an interior-point solver
+may be the better tool; see :ref:`when_not_scs` below.
+
+:code:`eps_infeas` (default :code:`1e-7`) controls how readily SCS declares a
+problem infeasible or unbounded. Decrease it if you see spurious certificates on
+a problem you know to be feasible; see :ref:`infeasibility`.
+
+Solve sequences of problems with a cached workspace
+---------------------------------------------------
+
+If you solve many problems that share :math:`A` and :math:`P` and differ only
+in :math:`b` and :math:`c`, initialize once and reuse the workspace. In C that
+is :code:`scs_init` followed by repeated :code:`scs_update` and
+:code:`scs_solve` calls (see the :ref:`C interface <c_interface>`); in Python it
+is one :code:`scs.SCS` object with :code:`update` and :code:`solve`. The matrix
+factorization and the equilibration are computed once and reused, which is
+usually the dominant cost of a solve.
+
+Warm-start whenever the previous solution is close to the next one, as in a
+model-predictive-control loop or when tracing a regularization path. Pass the
+previous :math:`x`, :math:`y` and :math:`s`; SCS starts from them and
+overwrites them with the new solution. See :ref:`warm_start` and the
+:ref:`MPC example <py_mpc>`.
+
+Pick the right linear solver
+----------------------------
+
+Every iteration solves one linear system with a fixed matrix, and the choice
+of how to solve it is the main performance decision. The
+:ref:`linear solver <linear_solver>` page describes each backend; as a rule of
+thumb:
+
+* **Default (sparse direct, QDLDL).** Factorizes once and reuses the factors.
+  Right for most problems up to a few hundred thousand nonzeros. Always
+  available.
+* **MKL Pardiso.** A parallel direct solver, often several times faster than
+  the default on large problems. Bundled in the x86-64 Linux and Windows Python
+  wheels and selected automatically there; see :ref:`mkl`.
+* **Apple Accelerate.** Available on macOS; selected explicitly. See
+  :ref:`apple_accelerate`.
+* **Sparse indirect (conjugate gradient).** Never factorizes, so it handles
+  problems too large to factorize and can be run matrix-free. Each iteration
+  is cheaper but there are more of them, and it is less predictable. See
+  :ref:`indirect`.
+* **cuDSS on the GPU.** The recommended GPU backend, a direct solver on the
+  device. The older GPU indirect solver is a legacy backend that only pays off
+  for very large problems. See :ref:`cudss_solver` and :ref:`gpu_indirect`.
+
+For the Python interface, :code:`linear_solver=scs.LinearSolver.AUTO` (the
+default) picks the best available direct solver for the platform.
+
+Leave acceleration on, but know how to turn it off
+--------------------------------------------------
+
+:ref:`Anderson acceleration <acceleration>` is on by default (type-I, memory
+:code:`10`, applied every :code:`5` iterations) and usually reduces the
+iteration count substantially, especially at tight tolerances. It can also
+destabilize the solve on some problems. If you see the residuals jump around
+rather than decrease, or a solve that stalls, set
+:code:`acceleration_lookback=0` and compare. The :code:`aa_stats` field of the
+returned info reports how many accelerated steps were accepted and why any were
+rejected, which is the place to look when tuning
+:code:`acceleration_regularization`.
+
+Read the log
+------------
+
+With :code:`verbose` on, SCS prints the problem dimensions, the cones, the
+settings and the linear solver, then one line every few iterations with the
+primal residual, dual residual, duality gap, objective, current :code:`scale`
+and elapsed time, and finally a status line and the timings broken down into
+linear-system solves, cone projections and acceleration. Two habits pay off:
+
+* Check the header the first time you solve a new problem. If the dimensions
+  or cones are not what you expect, the data is wrong and nothing downstream
+  will help.
+* Watch which residual is lagging. If one of primal and dual residual is far
+  ahead of the other, the problem is badly scaled between constraints and
+  objective; the adaptive scaling will try to correct it, and you can help by
+  rescaling.
+
+The status :code:`solved_inaccurate` means SCS stopped at :code:`max_iters` or
+:code:`time_limit_secs` before meeting the tolerances; the returned point is
+the best found and is often perfectly usable. See the :doc:`help page </help/index>` for what to
+try next.
+
+Interpret infeasibility certificates correctly
+----------------------------------------------
+
+SCS returns a certificate rather than a solution when it finds one (see
+:ref:`infeasibility`). Before trusting a certificate you did not expect, check
+the two most common causes of a spurious one: the rows of :math:`A` and
+:math:`b` not following the required :ref:`cone order <cones>`, and a sign or
+transposition error in the data. Setting :code:`write_data_filename` dumps
+exactly what SCS received, which is the fastest way to inspect it.
+
+Differentiating through SCS
+---------------------------
+
+Packages such as diffcp and cvxpylayers compute derivatives of the solution
+with respect to the problem data using the solution SCS returns. The accuracy
+of those derivatives is limited by the accuracy of that solution, and default
+tolerances are usually too loose for the purpose: pass tight tolerances (of
+order :code:`1e-8` or better) when a solve feeds a derivative computation, and
+expect finite-difference checks against such derivatives to be limited by the
+solve accuracy divided by the step size.
+
+.. _when_not_scs:
+
+When to use something else
+--------------------------
+
+SCS is the right tool for large problems, for problems with semidefinite,
+exponential or power cones, for problems that need infeasibility detection,
+and for sequences of related problems. It is not the best tool for a small
+problem that needs a highly accurate answer: an interior-point solver will
+reach :code:`1e-8` in tens of iterations where a first-order method needs
+thousands. For pure quadratic programs at modest accuracy a dedicated QP solver
+may also be faster. Modeling layers such as CVXPY choose a default solver by
+problem class for exactly this reason, and SCS is their default for the classes
+where it is strongest.
+
+Reporting problems
+------------------
+
+If SCS misbehaves on a problem, set :code:`write_data_filename`, attach the
+resulting file to a GitHub issue together with the settings you used and the
+solver log, and say what you expected instead. That is almost always enough to
+reproduce the behavior; see the :doc:`help page </help/index>`.

--- a/docs/src/guide/index.rst
+++ b/docs/src/guide/index.rst
@@ -1,0 +1,36 @@
+:orphan:
+
+.. This is the master document of the PDF user guide only (see latex_documents
+   in conf.py). It is not linked from the site, whose navigation is the root
+   toctree in index.rst. Pages are listed here selectively: the guide covers
+   the C and Python interfaces and the material every user needs, and points
+   to the site for the other language interfaces and the worked examples.
+
+SCS User Guide
+==============
+
+This guide describes how to use SCS, the Splitting Conic Solver, through its
+C and Python interfaces: how to install it, how to pose a problem in the form
+it accepts, what its settings do, how to choose a linear-solver backend, and
+what to do when a solve does not go as expected. The algorithm itself is
+described near the end, as background. The release number on the title page
+identifies the version of SCS the guide describes.
+
+The MATLAB, Julia, R, Ruby and JavaScript interfaces, and worked examples
+with their solver output, are documented on the website,
+https://www.cvxgrp.org/scs/, from which this guide is generated.
+
+To cite SCS, please cite the published papers listed in the final chapter
+rather than this guide.
+
+.. toctree::
+   :maxdepth: 2
+
+   install
+   api
+   /linear_solver/index
+   /blas_lapack/index
+   best_practices
+   /help/index
+   /algorithm/index
+   /citing/index

--- a/docs/src/guide/install.rst
+++ b/docs/src/guide/install.rst
@@ -1,0 +1,14 @@
+:orphan:
+
+Install
+=======
+
+SCS can be installed as a C library or as a Python package. Instructions for
+the MATLAB, Julia, R, Ruby and JavaScript interfaces are on the website at
+https://www.cvxgrp.org/scs/install/.
+
+.. toctree::
+   :maxdepth: 2
+
+   /install/c
+   /install/python

--- a/docs/src/index.rst
+++ b/docs/src/index.rst
@@ -114,17 +114,30 @@ guide </contributing/index>`.
 
 
 
+User guide
+----------
+
+This documentation is also built as a single versioned PDF, the `SCS User
+Guide <scs_user_guide.pdf>`_, from the same sources as this site; the release
+number on its title page identifies the version of SCS it describes. It is a
+guide to using the software rather than a description of the method: to cite
+SCS, please use the :doc:`published papers </citing/index>`.
+
+.. The order below is the order of the PDF user guide: install and use first,
+   the algorithm as background near the end.
+
 .. toctree::
    :hidden:
    :maxdepth: 2
 
-   algorithm/index
-   api/index
    install/index
+   api/index
    linear_solver/index
    blas_lapack/index
    examples/index
-   contributing/index
+   guide/best_practices
    help/index
+   algorithm/index
+   contributing/index
    citing/index
 


### PR DESCRIPTION
Draft for discussion, following #474: a user's guide as a single versioned PDF, generated from the same Sphinx sources as the site so it cannot drift from it.

- `make guide` in `docs/src` renders a curated subset of the docs through Sphinx's LaTeX builder into `_build/latex/scs_user_guide.pdf`, running pdflatex directly so the only extra requirement is a TeX installation. The release number from `conf.py` appears on the title page, which is what versions the guide.
- The PDF has its own master document, `guide/index.rst`, which selects what it contains: C and Python install and API, cones, matrices, settings, info, exit flags, compile flags, linear solvers, BLAS/LAPACK, best practices, help, the algorithm as background, and citing. It points to the site for the other language interfaces and the worked examples. 62 pages.
- The docs workflow installs TeX and publishes the PDF next to the site as `scs_user_guide.pdf`; the front page links to it and says to cite the published papers rather than the guide.
- The root toctree is reordered into guide order (install and use first, the algorithm as background), which changes the site's navigation order too.
- `guide/best_practices.rst` is a new draft chapter (scaling, tolerances, workspace reuse, backend choice, acceleration, reading the log, certificates, differentiating through SCS, when to use something else). It is written for maintainer review and every recommendation in it should be checked.
- Layout for print: the cone, settings, compile-flag and info tables get explicit column widths, the settings and compile-flag tables become page-breaking longtables, tables are set a size down in the PDF, the vertical spacing around C API entries is tightened, and `ScsCone`, `ScsSettings` and `ScsInfo` are shown in outline form with a pointer to the table that documents each field.
- Algorithm pages audited against `src/scs.c` and `include/glbopts.h`: the embedding (`u`, `Q`, `C_+`) is now defined on the algorithm page; `root_plus` is written in terms of the cached `g = (R + M)^{-1}(c, -b)` and per-iteration `p` rather than an undefined `r`; the adaptive-scale band is `[1/10, 10]` on the geometric-mean ratio, not `[1/3, 3]`; and a sign typo in the unequilibrated primal residual is fixed. Every quoted default was checked.
- Two source fixes the LaTeX build needed: the JavaScript example's `.. math::` blocks carry their own `align*`, which LaTeX rejects inside Sphinx's `split` wrapper, so they are marked `:nowrap:` (no change to the HTML rendering); and a few Unicode math symbols that reach the PDF through code comments are declared in the preamble.

Built locally: Sphinx `-W` clean for both the HTML and LaTeX builders.

🤖 Generated with [Claude Code](https://claude.com/claude-code)